### PR TITLE
ci: deploy to Vercel through the pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,13 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  # Quality gate: type-check, unit tests, and a full production build.
+  # Redundant runs on the same ref are cancelled.
+  verify:
     runs-on: ubuntu-latest
-
+    concurrency:
+      group: verify-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 
@@ -28,3 +32,74 @@ jobs:
 
       - name: Build
         run: npx next build
+
+  # Deploy to Vercel through the pipeline (not the native Git integration).
+  # Production on pushes to main; preview on pull requests.
+  # No-ops with a clear message until the three Vercel secrets are configured.
+  # Its own concurrency group WITHOUT cancellation, so an in-flight production
+  # deploy is never interrupted by a newer push.
+  deploy:
+    needs: verify
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: false
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Check Vercel secrets
+        id: guard
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Vercel deploy skipped";
+              echo "Set repository secrets \`VERCEL_TOKEN\`, \`VERCEL_ORG_ID\` and \`VERCEL_PROJECT_ID\` to enable pipeline deploys.";
+              echo "See \`docs/DEPLOYMENT.md\`.";
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.guard.outputs.ok == 'true'
+
+      - uses: actions/setup-node@v4
+        if: steps.guard.outputs.ok == 'true'
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Vercel CLI
+        if: steps.guard.outputs.ok == 'true'
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment (preview)
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'pull_request'
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Pull Vercel environment (production)
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'push'
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build (preview)
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'pull_request'
+        run: vercel build --token="$VERCEL_TOKEN"
+
+      - name: Build (production)
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'push'
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy (preview)
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'pull_request'
+        run: |
+          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          echo "**Preview:** $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Deploy (production)
+        if: steps.guard.outputs.ok == 'true' && github.event_name == 'push'
+        run: |
+          url=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          echo "**Production:** $url" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ All point values, pathway rules and per-state occupation lists live in `src/data
 
 ## 🌐 Deployment
 
-The application is automatically deployed to Vercel when changes are pushed to the main branch.
+Deployment runs **through the GitHub Actions pipeline** (`.github/workflows/ci.yml`): every push to
+`main` is type-checked, tested and built, then deployed to Vercel production; pull requests get preview
+deployments. See [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for the one-time secret setup
+(`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).
 
 - Production: [https://eoi-points-calculator.vercel.app](https://eoi-points-calculator.vercel.app)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,63 @@
+# Deployment
+
+The app deploys to Vercel **through the GitHub Actions pipeline** (`.github/workflows/ci.yml`),
+not through Vercel's native Git integration. This keeps deployment reproducible and version-controlled,
+and avoids the situation where the native Git integration silently stops triggering builds.
+
+## Pipeline behaviour
+
+The `CI` workflow has two jobs:
+
+1. **verify** — type-check (`tsc --noEmit`), unit tests (`vitest`), and a full `next build`.
+2. **deploy** — runs only after `verify` passes:
+   - **push to `main`** → production deployment (`vercel deploy --prebuilt --prod`)
+   - **pull request** → preview deployment (`vercel deploy --prebuilt`)
+   - The deploy URL is written to the job summary.
+
+If the Vercel secrets are not configured, the deploy job **skips cleanly** (green) with a note in the
+job summary — it never fails the pipeline.
+
+## One-time setup
+
+### 1. Add repository secrets
+
+In **GitHub → repo → Settings → Secrets and variables → Actions**, add:
+
+| Secret              | Where to get it                                                                 |
+|---------------------|---------------------------------------------------------------------------------|
+| `VERCEL_TOKEN`      | Vercel → Account Settings → Tokens → **Create Token**                            |
+| `VERCEL_ORG_ID`     | Run `vercel link` locally, then read `.vercel/project.json` → `orgId`            |
+| `VERCEL_PROJECT_ID` | Same file → `projectId` (or Vercel → Project → Settings → **Project ID**)        |
+
+Quick way to get the IDs:
+
+```bash
+npm i -g vercel
+vercel link            # links this repo to the existing Vercel project
+cat .vercel/project.json   # copy orgId + projectId
+```
+
+> `.vercel/` is git-ignored — do not commit it.
+
+### 2. Disable Vercel's native Git auto-deploy (avoid double deploys)
+
+Because the pipeline now deploys, turn off Vercel's own Git deploys so a single push doesn't deploy twice:
+
+- **Vercel → Project → Settings → Git → Ignored Build Step** → set to `exit 0` (skips Vercel-native builds), **or**
+- **Vercel → Project → Settings → Git** → disconnect the repository.
+
+The Actions pipeline remains the single source of truth for deploys.
+
+## Node version
+
+Next.js 16 requires **Node ≥ 20.9**. This is pinned in `package.json` (`engines.node`) and the workflow
+uses Node 22, so Vercel's build container will use a compatible runtime. If you ever deploy via the Vercel
+dashboard instead, set **Project → Settings → Node.js Version** to **20.x or 22.x** (an old default of 18.x
+will fail the Next 16 build).
+
+## Troubleshooting
+
+- **Pipeline green but nothing deployed** → secrets missing; check the deploy job summary.
+- **`Error: The specified token is not valid`** → regenerate `VERCEL_TOKEN`.
+- **`Project not found`** → `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` mismatch; re-run `vercel link`.
+- **Build fails only on Vercel** → confirm the project's Node.js version is 20.x/22.x.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest"
+  },
+  "engines": {
+    "node": ">=20.9.0"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.2.1",


### PR DESCRIPTION
## Problem

Vercel's native Git integration **stopped triggering deployments** — the latest `main` commit (`932eb59`, the v2 redesign) has **zero Vercel deployments** and no commit status, while earlier commits deployed fine. The dashboard-side integration can't be fixed from the repo, so this moves deployment into the CI pipeline where it's reproducible and version-controlled.

## Changes

- **Pipeline deploy** — new `deploy` job (runs after `verify` passes) uses the Vercel CLI: production on pushes to `main`, preview on PRs. Deploy URL is written to the job summary.
- **Safe until configured** — the deploy job **no-ops (green)** with a job-summary note until the three secrets (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`) are set, so it never fails the pipeline.
- **Concurrency** — `verify` cancels redundant runs; `deploy` uses a **separate non-cancelling group** so an in-flight production deploy is never aborted by a newer push (fix from adversarial review).
- **Node pinned** — `engines.node >=20.9.0` (Next 16 requires it; an old Vercel Node-18 default would hard-fail the build). Dropped the dead `next lint` script (removed in Next 16).
- **Docs** — `docs/DEPLOYMENT.md`: one-time secret setup + how to disable Vercel's native auto-deploy to avoid double deploys.

## Test plan

- [x] `tsc --noEmit`, `vitest run` (44 pass), `next build` all pass locally (the `verify` job)
- [x] `ci.yml` validated as YAML; two jobs with correct `needs`/`concurrency`/`env`
- [x] Adversarially reviewed (Vercel CLI flow + GitHub Actions semantics); the one major finding (shared cancel-in-progress on deploy) is fixed
- [ ] After merge: add the three Vercel secrets → next push to `main` produces a production deployment

> Requires one-time secret setup — see `docs/DEPLOYMENT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)