### PR TITLE
fix: correct occupation-list data from 2025-26 audit

### DIFF
--- a/docs/OCCUPATION-AUDIT.md
+++ b/docs/OCCUPATION-AUDIT.md
@@ -1,0 +1,91 @@
+# Occupation-list audit — 2025–26 program year
+
+**Audited:** 2026-07 · **Scope:** federal 189/190/491 occupation-list model + 8 state/territory 190/491 lists
+· **Files:** `src/data/occupations.ts`, `src/data/stateLists.ts`, `src/data/pointsCriteria.ts`
+
+This records a research + audit pass against official sources and the changes applied. Data changes
+are data-driven (in `src/data/`) — nothing was hardcoded into UI or the engine.
+
+## Executive summary
+
+- **The MLTSSL / STSOL / ROL model is correct** for the points-tested visas (189/190/491). The
+  December 2024 **CSOL** reform applies to the Skills in Demand **subclass 482** only — it does **not**
+  touch 189/190/491. No structural change needed. *(High confidence — primary legislation.)*
+- **Gate logic in `pointsCriteria.ts` is right:** 189 = MLTSSL; 190 = MLTSSL+STSOL; 491 = MLTSSL+STSOL+ROL.
+- **Fixed (P0):** three ICT occupations were mislabelled `MLTSSL` but are `STSOL`, which falsely granted
+  subclass-189 eligibility.
+- **Fixed (P1):** VIC, TAS and NT have **no fixed occupation list** — they accept any federally-eligible
+  occupation and select competitively. They are now modelled as open lists.
+- **Fixed (P2):** provenance comments + ACT list name corrected.
+
+## Legal basis
+
+- **Instrument:** *Migration (LIN 19/051) Instrument 2019* — register ID **F2019L00278**, in force;
+  latest compilation **F2026C00265** (28 Mar 2026). Sections 8/9/10 define MLTSSL / STSOL / ROL.
+- **CSOL:** created by *Migration (Specification of Occupations—Subclass 482 Visa) Instrument 2024*
+  (**F2024L01620 / LIN 24/089**, commenced 7 Dec 2024) for subclass 482, plus subclass 186 (F2024L01618).
+  Scoped to 482/186 — **not** 189/190/491.
+- Two research-pass claims were **dropped as refuted**: (a) that 189/190 migrated to CSOL while 491 did
+  not (all three remain MLTSSL-based); (b) `F2019C00855` as the "latest compilation" (superseded 2019 doc).
+
+## Changes applied
+
+### P0 — federal reclassification (`occupations.ts`)
+
+Currently `MLTSSL`, corrected to `STSOL` (removes false 189 eligibility; 190/491 unaffected since both include STSOL):
+
+| ANZSCO | Occupation             | Was    | Now   | Confidence |
+|--------|------------------------|--------|-------|------------|
+| 262113 | Systems Administrator  | MLTSSL | STSOL | high       |
+| 261314 | Software Tester        | MLTSSL | STSOL | high       |
+| 262111 | Database Administrator | MLTSSL | STSOL | high       |
+
+Cleared (already correct, no change): `221214` Internal Auditor (MLTSSL), `241213` Primary School
+Teacher (STSOL), `261111` ICT Business Analyst (MLTSSL), `261112` Systems Analyst (MLTSSL).
+
+### P1 — no-fixed-list states (`stateLists.ts`)
+
+VIC, TAS and NT do not gate on a published occupation list — they accept any occupation on the relevant
+federal SOL and select competitively (ROI / Canberra-style matrix). They are now `openListStates`:
+`statesListing()` returns them for any occupation that passes the federal gate, instead of the previous
+narrow sector groups which wrongly excluded valid occupations. Their sector entries remain as indicative
+**priority sectors** only.
+
+### P2 — provenance / naming
+
+- `occupations.ts` header now cites F2019L00278 and states the CSOL exclusion explicitly.
+- ACT description corrected: "Critical Skills List" → "ACT Nominated Migration Program Occupation List
+  + Canberra Matrix" (both locales).
+
+## Per-state program structure (verified) vs list membership (approximated)
+
+Program **structure** (fixed-list-or-not, selection method) was verified at high confidence. Actual
+per-state ANZSCO **membership** for the fixed-list states is a curated sector-group approximation —
+reference only.
+
+| State | Fixed list? | Selection mechanism |
+|-------|-------------|---------------------|
+| NSW | Yes (190 & 491, published at 4-digit unit-group) | Fixed list + EOI invitation rounds |
+| VIC | **No** | ROI ranking; accepts any federal-SOL occupation |
+| QLD | Yes (QSOL, onshore/offshore) | ROI ranking |
+| WA  | Yes (WASMOL Sch 1 & 2 + Graduate) | Fixed list + ranked monthly rounds |
+| SA  | Yes (single list, per-occupation 190/491 flags) | ROI (onshore) / EOI (offshore) |
+| TAS | **No** | ROI ranking with priority pass categories |
+| ACT | Yes (ACT Nominated Migration Program Occupation List) | Fixed list + Canberra Matrix |
+| NT  | **No** onshore (offshore Priority stream uses NTOMOL) | EOI/registration, weighted |
+
+## Confidence & remaining gaps
+
+- **High:** federal legal basis, CSOL determination, the three reclassifications, per-state program structure.
+- **Low:** exact ANZSCO membership of each state's live list (sector-group approximations, unverified).
+- **Not done (future work):**
+  - Full code-by-code reconciliation of all 70 shipped occupations against the rendered primary
+    Home Affairs / F2019L00278 schedule (7 verified this pass; `immi.homeaffairs.gov.au` returns HTTP 403
+    to automated fetches, so a browser pass is needed).
+  - Replace fixed-list-state sector approximations (NSW, QLD, WA, SA, ACT) with the actual published
+    ANZSCO codes (NSW publishes at 4-digit unit-group level).
+  - Program allocations for QLD/TAS/NT 2025–26 are already exhausted — consider surfacing a
+    "program may be closed" caveat.
+
+Re-verify at the start of each program year; a future GSM list consolidation was signalled but had not
+taken effect as of July 2026.

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -149,7 +149,7 @@
       "tip": "Usually 6–9 months of TAS work; settlement focus"
     },
     "ACT": {
-      "how": "Critical Skills List + Canberra Matrix scoring",
+      "how": "ACT Nominated Migration Program Occupation List + Canberra Matrix",
       "tip": "Canberra residence & work history required; mostly local invitees"
     },
     "NT": {

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -149,7 +149,7 @@
       "tip": "通常需州内工作 6–9 个月；强调长期定居"
     },
     "ACT": {
-      "how": "Critical Skills List + Canberra Matrix 打分",
+      "how": "ACT 提名迁移计划职业清单 + Canberra Matrix 打分",
       "tip": "需堪培拉居住与工作记录；本地申请人占绝大多数"
     },
     "NT": {

--- a/src/data/occupations.ts
+++ b/src/data/occupations.ts
@@ -1,6 +1,9 @@
-// 技术移民职业清单 — 来源: immi.homeaffairs.gov.au
-// MLTSSL = 189/190/491, STSOL = 190/491, ROL = 491 only
-// 最后更新: 2026-03
+// 技术移民职业清单 (points-tested GSM visas)
+// Legal basis: Migration (LIN 19/051) Instrument 2019 — register ID F2019L00278
+//   (still in force; latest compilation F2026C00265, 28 Mar 2026). s8/s9/s10 define MLTSSL/STSOL/ROL.
+// Gate: MLTSSL = 189/190/491, STSOL = 190/491, ROL = 491 only.
+// NOTE: the CSOL (Dec 2024) applies to the Skills in Demand subclass 482 only — NOT to 189/190/491.
+// This is a curated subset for the calculator, not the full instrument. 最后审计: 2026-07
 export interface Occupation {
   anzsco: string;
   en: string;
@@ -13,15 +16,15 @@ export const occupations: Occupation[] = [
   { anzsco: '261313', en: 'Software Engineer', zh: '软件工程师', list: 'MLTSSL' },
   { anzsco: '261311', en: 'Analyst Programmer', zh: '分析程序员', list: 'MLTSSL' },
   { anzsco: '263111', en: 'Computer Network and Systems Engineer', zh: '网络与系统工程师', list: 'MLTSSL' },
-  { anzsco: '262113', en: 'Systems Administrator', zh: '系统管理员', list: 'MLTSSL' },
+  { anzsco: '262113', en: 'Systems Administrator', zh: '系统管理员', list: 'STSOL' },
   { anzsco: '262112', en: 'ICT Security Specialist', zh: 'ICT安全专家', list: 'MLTSSL' },
   { anzsco: '261111', en: 'ICT Business Analyst', zh: 'ICT业务分析师', list: 'MLTSSL' },
   { anzsco: '261112', en: 'Systems Analyst', zh: '系统分析师', list: 'MLTSSL' },
   { anzsco: '263312', en: 'Telecommunications Network Engineer', zh: '电信网络工程师', list: 'MLTSSL' },
-  { anzsco: '261314', en: 'Software Tester', zh: '软件测试员', list: 'MLTSSL' },
+  { anzsco: '261314', en: 'Software Tester', zh: '软件测试员', list: 'STSOL' },
   { anzsco: '135112', en: 'ICT Project Manager', zh: 'ICT项目经理', list: 'STSOL' },
   { anzsco: '135111', en: 'Chief Information Officer', zh: '首席信息官', list: 'STSOL' },
-  { anzsco: '262111', en: 'Database Administrator', zh: '数据库管理员', list: 'MLTSSL' },
+  { anzsco: '262111', en: 'Database Administrator', zh: '数据库管理员', list: 'STSOL' },
   { anzsco: '224711', en: 'Management Consultant', zh: '管理咨询师', list: 'STSOL' },
   { anzsco: '221111', en: 'Accountant (General)', zh: '会计师（综合）', list: 'MLTSSL' },
   { anzsco: '221112', en: 'Management Accountant', zh: '管理会计师', list: 'MLTSSL' },

--- a/src/data/stateLists.ts
+++ b/src/data/stateLists.ts
@@ -1,13 +1,19 @@
 // State / territory nomination lists for subclass 190 and 491.
 // Each state keeps its OWN occupation list on top of the federal
 // MLTSSL / STSOL / ROL gate — an occupation eligible federally may still
-// be absent from a given state's list.
+// be absent from a given state's fixed list.
 //
-// Snapshot of the 2025–26 program year, curated from each state's official
-// migration site (see `url` per state). States without a fixed published
-// list (VIC ROI, TAS pathways) are represented by their published priority
-// sectors. Reference only — always verify on the official page.
-// Last updated: 2026-03
+// Snapshot of the 2025–26 program year. IMPORTANT: for the FIXED-LIST states
+// (NSW, QLD, WA, SA, ACT) the code sets below are curated sector-group
+// APPROXIMATIONS, not the verbatim published lists — reference only, verify on
+// each state's official page (`url`). Program STRUCTURE per state is verified;
+// exact ANZSCO membership is not.
+//
+// VIC, TAS and NT do NOT gate on a fixed occupation list: they accept any
+// occupation on the relevant federal SOL and select competitively (ROI / matrix).
+// They are handled as `openListStates` below — their entries here are indicative
+// PRIORITY sectors only, not an eligibility gate. Being listed ≠ likely invitation.
+// Last audited: 2026-07 (see docs / audit report)
 
 import type { VisaCode } from './pointsCriteria';
 
@@ -107,8 +113,24 @@ export const stateOccupationLists: Record<StateCode, Record<Extract<VisaCode, '1
   },
 };
 
-/** States whose 190/491 list includes the given occupation (federal gate NOT applied here) */
+/**
+ * States/territories with NO fixed occupation list — they accept any occupation
+ * on the relevant federal SOL and select competitively (ROI / Canberra-style matrix).
+ * Modelled as "open": listed for any occupation that passes the federal gate.
+ * (NT is open onshore; its offshore Priority stream uses NTOMOL — simplified here to
+ * open, erring toward inclusion, matching the onshore reality.)
+ */
+export const openListStates: StateCode[] = ['VIC', 'TAS', 'NT'];
+
+/**
+ * States whose 190/491 list includes the given occupation.
+ * The caller applies the federal MLTSSL/STSOL/ROL gate first, so open-list states
+ * are returned for any occupation reaching this function; fixed-list states are
+ * returned only when their curated list includes the code.
+ */
 export function statesListing(anzsco: string, visa: '190' | '491'): StateCode[] {
   if (!anzsco) return [];
-  return stateCodes.filter((s) => stateOccupationLists[s][visa].includes(anzsco));
+  return stateCodes.filter(
+    (s) => openListStates.includes(s) || stateOccupationLists[s][visa].includes(anzsco),
+  );
 }

--- a/tests/points.test.ts
+++ b/tests/points.test.ts
@@ -8,7 +8,7 @@ import {
 import { defaultSharedCriteria, newJob } from '@/lib/types';
 import type { JobAssessment, SharedCriteria } from '@/lib/types';
 import { occupations } from '@/data/occupations';
-import { statesListing, stateOccupationLists } from '@/data/stateLists';
+import { openListStates, statesListing, stateOccupationLists } from '@/data/stateLists';
 
 function makeShared(overrides: Partial<SharedCriteria> = {}): SharedCriteria {
   return { ...defaultSharedCriteria, ...overrides };
@@ -219,6 +219,39 @@ describe('evaluate', () => {
     const ev = evaluate(shared, [makeJob({ anzsco: '261313' })]);
     expect(ev.jobs[0].pathways.every((p) => !p.eligible)).toBe(true);
     expect(ev.best).toBeNull();
+  });
+});
+
+// --- occupation list audit (2026-07) ---
+describe('federal classification audit', () => {
+  it.each([
+    ['262113', 'Systems Administrator'],
+    ['261314', 'Software Tester'],
+    ['262111', 'Database Administrator'],
+  ])('%s (%s) is STSOL: not 189-eligible, still 190/491-eligible', (anzsco) => {
+    expect(findOccupation(anzsco)?.list).toBe('STSOL');
+    // 65-point applicant so points are not the limiting factor
+    const shared = makeShared({ age: '25-32', english: 'ielts7', education: 'bachelor', partnerStatus: 'single' });
+    const paths = evaluate(shared, [makeJob({ anzsco })]).jobs[0].pathways;
+    const by = (code: string) => paths.find((p) => p.code === code)!;
+    expect(by('189').listOk).toBe(false);
+    expect(by('189').eligible).toBe(false);
+    expect(by('190').listOk).toBe(true);
+    expect(by('491').listOk).toBe(true);
+  });
+});
+
+describe('open-list states (VIC / TAS / NT)', () => {
+  it('nominate any occupation, even outside their priority sector groups', () => {
+    // 271311 Solicitor is not in the VIC/TAS/NT priority groups, but they have no fixed list
+    const states = statesListing('271311', '190');
+    for (const s of openListStates) expect(states).toContain(s);
+  });
+
+  it('fixed-list states still gate by their curated list', () => {
+    const states = statesListing('271311', '190');
+    expect(states).toContain('SA'); // SA lists LEGAL
+    expect(states).not.toContain('NSW'); // NSW does not
   });
 });
 


### PR DESCRIPTION
## Summary

Research + audit of the 189/190/491 occupation lists against the current legal basis, with data-driven corrections. Full write-up in [`docs/OCCUPATION-AUDIT.md`](docs/OCCUPATION-AUDIT.md).

**Headline:** the repo's **MLTSSL / STSOL / ROL** model is correct for the points-tested visas. The Dec 2024 **CSOL** reform applies to the Skills in Demand **subclass 482** only — **not** 189/190/491 (governed by LIN 19/051 / F2019L00278, latest compilation 28 Mar 2026). No structural/gate change needed.

## Fixes

**P0 — federal reclassification (correctness bug):** three ICT occupations were labelled `MLTSSL` but are actually `STSOL`, which falsely showed them as subclass-189 eligible:

| ANZSCO | Occupation | Was | Now |
|--------|------------|-----|-----|
| 262113 | Systems Administrator | MLTSSL | STSOL |
| 261314 | Software Tester | MLTSSL | STSOL |
| 262111 | Database Administrator | MLTSSL | STSOL |

190/491 outcomes unaffected (both include STSOL); only the false 189 eligibility is removed.

**P1 — no-fixed-list states:** VIC, TAS and NT don't gate on a published occupation list — they accept any federally-eligible occupation and select competitively. Modelled as `openListStates` so `statesListing()` no longer wrongly excludes valid occupations; their sector entries are now indicative priority sectors only.

**P2 — provenance:** cite the governing instrument in the `occupations.ts` header; correct ACT's list name to "ACT Nominated Migration Program Occupation List + Canberra Matrix" (both locales).

## Confidence & scope

- **High:** legal basis, CSOL determination, the three reclassifications, per-state program structure.
- **Low (documented):** exact ANZSCO membership of each fixed-list state — these remain curated sector-group approximations. Full code-by-code reconciliation against the primary Home Affairs schedule is listed as future work in the audit doc (the site returns HTTP 403 to automated fetches).

Produced by a multi-agent research workflow (per-state + federal research, each adversarially verified, then synthesised); two unsupported research claims were dropped in verification.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 49 tests pass (5 new: STSOL reclassification + open-list states)
- [x] `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)