### PR TITLE
feat: headline shows bare score (裸分); allow 5 assessments

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -84,7 +84,7 @@
   "occNo": "No matching occupations",
   "occHint": "MLTSSL = 189/190/491 · STSOL = 190/491 · ROL = 491 only",
   "occCount": "{{n}} of {{m}}",
-  "totalCaps": "BEST TOTAL",
+  "totalCaps": "BASE POINTS · BEFORE NOMINATION",
   "points": "pts",
   "minimum": "Minimum",
   "goal": "Goal",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -84,7 +84,7 @@
   "occNo": "未找到匹配的职业",
   "occHint": "MLTSSL = 189/190/491 · STSOL = 190/491 · ROL = 仅 491",
   "occCount": "{{n}} / {{m}} 条",
-  "totalCaps": "最高总分 · BEST TOTAL",
+  "totalCaps": "裸分 · 未含州担保加分",
   "points": "分",
   "minimum": "最低要求",
   "goal": "目标",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,8 +57,9 @@ const PageContent = () => {
   const bandRef = useRef<HTMLDivElement | null>(null);
 
   const evaluation = useMemo(() => evaluate(shared, jobs), [shared, jobs]);
-  const totalPoints = evaluation.bestTotal;
-  const displayTotal = useAnimatedNumber(totalPoints);
+  // Headline number is the bare score (裸分) — before any state/regional nomination bonus.
+  const bareScore = evaluation.bareScore;
+  const displayTotal = useAnimatedNumber(bareScore);
 
   // Persist to localStorage + keep the URL shareable (debounced)
   const firstRender = useRef(true);
@@ -153,7 +154,7 @@ const PageContent = () => {
   if (!ready || !mounted) return <PageSkeleton />;
 
   const anySearchOpen = Object.values(jobUI).some((u) => u?.open);
-  const chipVisible = chipShown && totalPoints > 0 && !exportOpen && !openSelect && !anySearchOpen;
+  const chipVisible = chipShown && bareScore > 0 && !exportOpen && !openSelect && !anySearchOpen;
   const sec2Active = (openSelect !== null && !openSelect.startsWith('sh:')) || anySearchOpen;
 
   return (
@@ -223,7 +224,7 @@ const PageContent = () => {
         bandRef={bandRef}
       />
 
-      <ReferenceSection totalPoints={totalPoints} evaluation={evaluation} />
+      <ReferenceSection totalPoints={bareScore} evaluation={evaluation} />
 
       {/* Footer */}
       <footer
@@ -256,7 +257,7 @@ const PageContent = () => {
         </div>
       </footer>
 
-      <FloatingChip visible={chipVisible} total={totalPoints} onClick={scrollToResults} />
+      <FloatingChip visible={chipVisible} total={bareScore} onClick={scrollToResults} />
 
       <ExportModal
         open={exportOpen}

--- a/src/components/ResultsBand.tsx
+++ b/src/components/ResultsBand.tsx
@@ -80,7 +80,9 @@ export default function ResultsBand({
   const { t, i18n } = useTranslation();
   const lang = i18n.language?.startsWith('zh') ? 'zh' : 'en';
 
-  const total = evaluation.bestTotal;
+  // Headline reflects the bare score (裸分); per-pathway rows below show the
+  // nomination-inclusive totals (+5 / +15) and eligibility.
+  const total = evaluation.bareScore;
 
   let statusLine: string;
   let warnColor = 'var(--band-muted)';

--- a/src/data/pointsCriteria.ts
+++ b/src/data/pointsCriteria.ts
@@ -101,7 +101,7 @@ export const pathways: Pathway[] = [
 
 export const MIN_POINTS = 65;
 export const GOAL_RANGE = { min: 65, max: 120, step: 5 } as const;
-export const MAX_JOBS = 4;
+export const MAX_JOBS = 5;
 
 export function optionPoints(options: PointOption[], value: string): number {
   const opt = options.find((o) => o.value === value && value !== '');

--- a/src/lib/exportCard.ts
+++ b/src/lib/exportCard.ts
@@ -53,7 +53,8 @@ export async function ensureCardFonts(): Promise<void> {
 /** Draw the 1080×1440 share card. Colors come from cardThemes, values from the evaluation. */
 export function drawCard({ evaluation, goal, lang, theme, labels, dateLabel }: CardOptions): HTMLCanvasElement {
   const ev = evaluation;
-  const total = ev.bestTotal;
+  // Headline number is the bare score (裸分); pathway rows below carry the +5/+15 route totals.
+  const total = ev.bareScore;
   const C = cardPalettes[theme];
   const W = 1080, H = 1440, P = 96, IW = W - P * 2;
 

--- a/src/lib/points.ts
+++ b/src/lib/points.ts
@@ -60,6 +60,8 @@ export interface Evaluation {
   best: { total: number; code: VisaCode; job: JobEvaluation } | null;
   /** Best eligible pathway total, or highest base when nothing is eligible yet */
   bestTotal: number;
+  /** Highest base score across jobs — the "裸分" before any state/regional nomination bonus */
+  bareScore: number;
 }
 
 export function calculateSharedPoints(shared: SharedCriteria): SharedPoints {
@@ -125,9 +127,9 @@ export function evaluate(shared: SharedCriteria, jobs: JobAssessment[]): Evaluat
     }
   }
 
-  const bestTotal = best
-    ? best.total
-    : jobEvaluations.reduce((max, je) => Math.max(max, je.base), 0);
+  // Bare score (裸分): the highest base across jobs, before any nomination bonus.
+  const bareScore = jobEvaluations.reduce((max, je) => Math.max(max, je.base), 0);
+  const bestTotal = best ? best.total : bareScore;
 
-  return { shared: sharedPoints, sharedTotal, jobs: jobEvaluations, best, bestTotal };
+  return { shared: sharedPoints, sharedTotal, jobs: jobEvaluations, best, bestTotal, bareScore };
 }

--- a/tests/points.test.ts
+++ b/tests/points.test.ts
@@ -257,6 +257,25 @@ describe('open-list states (VIC / TAS / NT)', () => {
   });
 });
 
+describe('bareScore (裸分)', () => {
+  it('is the base before nomination, distinct from bestTotal', () => {
+    const shared = makeShared({ age: '25-32', english: 'ielts7', education: 'bachelor', partnerStatus: 'single' }); // 65
+    const ev = evaluate(shared, [makeJob({ anzsco: '261313' })]); // MLTSSL, base 65
+    expect(ev.bareScore).toBe(65); // no +5/+15 nomination bonus
+    expect(ev.bestTotal).toBe(80); // best pathway 491 = 65 + 15
+    expect(ev.best?.code).toBe('491');
+  });
+
+  it('takes the highest base across multiple jobs', () => {
+    const shared = makeShared({ age: '25-32' }); // 30
+    const ev = evaluate(shared, [
+      makeJob({ anzsco: '261313' }), // base 30
+      makeJob({ anzsco: '221111', ausWork: '5-8' }), // base 30 + 15 = 45
+    ]);
+    expect(ev.bareScore).toBe(45);
+  });
+});
+
 describe('data integrity', () => {
   it('every state list only references known ANZSCO codes', () => {
     const known = new Set(occupations.map((o) => o.anzsco));


### PR DESCRIPTION
## Summary

Two requested changes:

1. **Headline = bare score (裸分).** The big number (results band, floating chip, export card) now shows the **base score before any state/regional nomination bonus** — not the best pathway total that included +5/+15. The per-pathway rows still show the route totals (189 / 190 +5 / 491 +15) and eligibility, so nothing is lost — the nomination detail just moves out of the headline. Label updated to `BASE POINTS · BEFORE NOMINATION` / `裸分 · 未含州担保加分`.
2. **Max assessments 4 → 5.**

## Details

- `evaluate()` now returns `bareScore` = highest `base` across assessments (shared points + that job's work/PY points, no pathway bonus). Headline number, status line and progress bar track it; `bestTotal` still drives the "best pathway — … · 491" line and the pathway rows.
- `MAX_JOBS` 4 → 5 (single constant; the add-assessment button and URL/localStorage slicing follow it).

## Verified

- [x] `tsc --noEmit` clean · `vitest run` 51 pass (2 new bareScore tests) · `next build` ok
- [x] Browser: 65-point applicant with an MLTSSL occupation shows headline **65** (bare) while rows show 189=65 / 190=70 / 491=80

🤖 Generated with [Claude Code](https://claude.com/claude-code)