### PR TITLE
fix: theme toggle affordance, a11y audit fixes, hi-res export card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # testing
 /coverage
+.playwright-mcp/
 
 # next.js
 /.next/

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'eoi-calc-v2';
+const CACHE_NAME = 'eoi-calc-v3';
 const STATIC_ASSETS = [
   '/',
   '/locales/en/common.json',
@@ -21,25 +21,39 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+function fetchAndCache(request) {
+  return fetch(request).then((response) => {
+    if (response.ok && request.url.startsWith(self.location.origin)) {
+      const clone = response.clone();
+      caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+    }
+    return response;
+  });
+}
+
 self.addEventListener('fetch', (event) => {
-  // Network-first for navigation, cache-first for static assets
-  if (event.request.mode === 'navigate') {
+  const { request } = event;
+
+  // Network-first for navigation so deploys reach users immediately
+  if (request.mode === 'navigate') {
+    event.respondWith(fetch(request).catch(() => caches.match('/')));
+    return;
+  }
+
+  // Hashed build assets are immutable — cache-first is safe
+  if (request.url.includes('/_next/static/')) {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match('/'))
+      caches.match(request).then((cached) => cached || fetchAndCache(request))
     );
     return;
   }
 
+  // Everything else (locales, icons…) is stale-while-revalidate:
+  // serve the cache for speed, refresh it in the background
   event.respondWith(
-    caches.match(event.request).then((cached) => {
-      if (cached) return cached;
-      return fetch(event.request).then((response) => {
-        if (response.ok && event.request.url.startsWith(self.location.origin)) {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-        }
-        return response;
-      });
+    caches.match(request).then((cached) => {
+      const refresh = fetchAndCache(request).catch(() => cached);
+      return cached || refresh;
     })
   );
 });

--- a/src/app/i18n/client.ts
+++ b/src/app/i18n/client.ts
@@ -25,4 +25,11 @@ i18next
     },
   });
 
-export default i18next; 
+// Keep <html lang> in sync so screen readers pick the right voice
+i18next.on('languageChanged', (lng) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = lng.startsWith('zh') ? 'zh-Hans' : 'en';
+  }
+});
+
+export default i18next;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,10 @@ const notoSerifSC = Noto_Serif_SC({
 });
 
 export const viewport = {
-  themeColor: '#F2EFE6',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#F2EFE6' },
+    { media: '(prefers-color-scheme: dark)', color: '#1E1C17' },
+  ],
 };
 
 export const metadata = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ import { useAnimatedNumber } from '@/hooks/useAnimatedNumber';
 import { evaluate } from '@/lib/points';
 import type { JobAssessment, SharedCriteria } from '@/lib/types';
 import { defaultSharedCriteria, newJob } from '@/lib/types';
-import { persistState, readInitialState, stateToQueryString } from '@/lib/urlState';
+import { mergeQueryString, persistState, readInitialState } from '@/lib/urlState';
 import { GOAL_RANGE, MAX_JOBS } from '@/data/pointsCriteria';
 import '@/app/i18n/client';
 
@@ -26,7 +26,7 @@ function PageSkeleton() {
     <div className="max-w-[780px] mx-auto px-[26px] pt-[34px]">
       <div className="h-4 w-28 mb-[72px]" style={{ backgroundColor: 'var(--hair)' }} />
       <div className="h-10 w-3/4 mb-[60px]" style={{ backgroundColor: 'var(--hair)' }} />
-      <div className="grid gap-x-9 gap-y-[30px]" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(290px, 1fr))' }}>
+      <div className="grid gap-x-9 gap-y-[30px]" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(290px, 100%), 1fr))' }}>
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i}>
             <div className="h-3 w-24 mb-2.5" style={{ backgroundColor: 'var(--hair)' }} />
@@ -67,7 +67,7 @@ const PageContent = () => {
     if (firstRender.current) { firstRender.current = false; return; }
     const id = setTimeout(() => {
       persistState(shared, jobs);
-      const qs = stateToQueryString(shared, jobs);
+      const qs = mergeQueryString(window.location.search, shared, jobs);
       window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash);
     }, 250);
     return () => clearTimeout(id);
@@ -171,7 +171,7 @@ const PageContent = () => {
       {/* 02 — Skills assessments */}
       <section
         className="mt-[72px] relative"
-        style={{ zIndex: sec2Active ? 30 : 'auto', animation: 'eoiFadeUp 0.7s ease 0.16s both' }}
+        style={{ zIndex: sec2Active ? 30 : 'auto', animation: 'eoiFadeUp 0.7s ease 0.16s backwards' }}
       >
         <SectionHeading num="02" title={t('sections.jobs')} side="ASSESSMENTS" />
         <p className="mt-3.5 mb-0 text-[12.5px] leading-[1.7] max-w-[46em]" style={{ color: 'var(--muted)' }}>

--- a/src/components/CheckRow.tsx
+++ b/src/components/CheckRow.tsx
@@ -13,6 +13,8 @@ export default function CheckRow({ label, checked, points, onToggle }: CheckRowP
   return (
     <button
       type="button"
+      role="checkbox"
+      aria-checked={checked}
       onClick={onToggle}
       className="flex items-start gap-3 w-full px-1.5 py-[13px] cursor-pointer text-left hover:bg-[var(--hover)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--muted)] focus-visible:-outline-offset-1"
       style={{
@@ -24,6 +26,7 @@ export default function CheckRow({ label, checked, points, onToggle }: CheckRowP
       }}
     >
       <span
+        aria-hidden="true"
         className="w-[15px] h-[15px] flex-none mt-0.5 flex items-center justify-center"
         style={{
           border: '1px solid var(--muted)',

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -30,6 +30,34 @@ export default function ExportModal({ open, onClose, evaluation, goal }: ExportM
   const [loading, setLoading] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const genSeqRef = useRef(0);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+  // Move focus into the dialog on open, give it back on close
+  useEffect(() => {
+    if (!open) return;
+    restoreFocusRef.current = document.activeElement as HTMLElement | null;
+    panelRef.current?.focus();
+    return () => restoreFocusRef.current?.focus();
+  }, [open]);
+
+  const trapTab = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab' || !panelRef.current) return;
+    const focusables = Array.from(
+      panelRef.current.querySelectorAll<HTMLElement>('button, a[href], input, [tabindex]:not([tabindex="-1"])'),
+    );
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && (active === first || active === panelRef.current)) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -100,12 +128,19 @@ export default function ExportModal({ open, onClose, evaluation, goal }: ExportM
     <div className="fixed inset-0 z-60 flex items-center justify-center p-[22px]">
       <div
         onClick={onClose}
+        aria-hidden="true"
         className="absolute inset-0"
-        style={{ background: 'var(--overlay-bg)', backdropFilter: 'blur(7px)', animation: 'eoiFadeIn 0.25s ease both' }}
+        style={{ background: 'var(--overlay-bg)', backdropFilter: 'blur(7px)', animation: 'eoiFadeIn 0.25s ease backwards' }}
       />
       <div
-        className="relative flex flex-col gap-3.5"
-        style={{ width: 'min(86vw, 380px)', animation: 'eoiModalIn 0.4s cubic-bezier(0.22, 1, 0.36, 1) both' }}
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('exportBtn')}
+        tabIndex={-1}
+        onKeyDown={trapTab}
+        className="relative flex flex-col gap-3.5 outline-none"
+        style={{ width: 'min(86vw, 380px)', animation: 'eoiModalIn 0.4s cubic-bezier(0.22, 1, 0.36, 1) backwards' }}
       >
         <div className="flex justify-between items-center">
           <div className="flex gap-3.5 text-xs">

--- a/src/components/FloatingChip.tsx
+++ b/src/components/FloatingChip.tsx
@@ -23,7 +23,7 @@ export default function FloatingChip({ visible, total, onClick }: FloatingChipPr
         color: 'var(--band-ink)',
         border: '1px solid var(--band-border)',
         boxShadow: 'var(--shadow)',
-        animation: 'eoiFadeUp 0.35s ease both',
+        animation: 'eoiFadeUp 0.35s ease backwards',
       }}
     >
       <span className="text-[10.5px] tracking-[0.18em] font-medium" style={{ color: 'var(--band-muted)' }}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from './ThemeProvider';
 
@@ -13,30 +14,39 @@ export default function Header() {
   const { t, i18n } = useTranslation();
   const { theme, setTheme } = useTheme();
 
+  // Theme is only known on the client; render the pre-mount state identically
+  // to the server markup to avoid hydration mismatches.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const lang = i18n.language?.startsWith('zh') ? 'zh' : 'en';
-  const resolvedTheme = theme === 'system'
-    ? (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-    : theme;
+  const resolvedTheme = mounted
+    ? (theme === 'system'
+      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : theme)
+    : 'light';
 
   const langButton = (code: 'zh' | 'en', label: string) => (
     <button
       type="button"
       onClick={() => i18n.changeLanguage(code)}
-      className="cursor-pointer text-xs py-1"
+      aria-pressed={lang === code}
+      className="cursor-pointer text-xs px-1.5 py-2 -my-1"
       style={{
         background: 'none',
         border: 'none',
         color: lang === code ? 'var(--ink)' : 'var(--muted)',
-        borderBottom: lang === code ? '1px solid var(--ink)' : '1px solid transparent',
         letterSpacing: code === 'zh' ? '0.06em' : '0.08em',
       }}
     >
-      {label}
+      <span style={{ borderBottom: lang === code ? '1px solid var(--ink)' : '1px solid transparent', paddingBottom: 2 }}>
+        {label}
+      </span>
     </button>
   );
 
   return (
-    <header className="pt-[34px]" style={{ animation: 'eoiFadeUp 0.7s ease both' }}>
+    <header className="pt-[34px]" style={{ animation: 'eoiFadeUp 0.7s ease backwards' }}>
       <div className="flex justify-between items-center gap-4">
         <div className="text-[11.5px] tracking-[0.24em] font-medium" style={{ color: 'var(--ink)' }}>
           EOI&nbsp;POINTS
@@ -51,14 +61,22 @@ export default function Header() {
             type="button"
             onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
             aria-label="Toggle theme"
+            aria-pressed={resolvedTheme === 'dark'}
             title={t('themeHint')}
-            className="w-[26px] h-[26px] rounded-full cursor-pointer p-0"
-            style={{
-              border: '1px solid var(--muted)',
-              background: resolvedTheme === 'dark' ? 'var(--ink)' : 'transparent',
-              transition: 'background 0.3s ease',
-            }}
-          />
+            className="theme-toggle w-[38px] h-[38px] -m-1.5 rounded-full cursor-pointer p-0 flex items-center justify-center"
+            style={{ background: 'none', border: 'none' }}
+          >
+            <span
+              aria-hidden="true"
+              className="block w-[26px] h-[26px] rounded-full"
+              style={{
+                border: '1px solid var(--muted)',
+                background: 'linear-gradient(90deg, var(--ink) 50%, transparent 50%)',
+                transform: resolvedTheme === 'dark' ? 'rotate(180deg)' : 'none',
+                transition: 'transform 0.35s ease',
+              }}
+            />
+          </button>
         </div>
       </div>
       <h1

--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import SelectField, { pointsTag } from './SelectField';
 import CheckRow from './CheckRow';
@@ -48,6 +49,8 @@ export default function JobCard({
 }: JobCardProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language?.startsWith('zh') ? 'zh' : 'en';
+  const searchId = useId();
+  const searchListId = `${searchId}-list`;
 
   const occ = evaluation.occupation;
   const tag = String.fromCharCode(65 + evaluation.index);
@@ -68,7 +71,7 @@ export default function JobCard({
         background: 'var(--surface)',
         padding: 'clamp(18px, 3.4vw, 28px)',
         zIndex: cardActive ? 30 : 1,
-        animation: 'eoiFadeUp 0.4s ease both',
+        animation: 'eoiFadeUp 0.4s ease backwards',
       }}
     >
       <div className="flex justify-between items-baseline gap-3.5">
@@ -90,7 +93,8 @@ export default function JobCard({
               type="button"
               onClick={onRemove}
               title={t('removeJob')}
-              className="cursor-pointer text-[17px] leading-none px-1 py-0.5 hover:text-[var(--danger)]"
+              aria-label={t('removeJob')}
+              className="cursor-pointer text-[17px] leading-none w-8 h-8 -my-2 flex items-center justify-center hover:text-[var(--danger)]"
               style={{ background: 'none', border: 'none', color: 'var(--muted)' }}
             >
               ×
@@ -101,7 +105,11 @@ export default function JobCard({
 
       {/* Occupation: searchable dropdown */}
       <div data-dd="true" className="relative mt-[18px]">
-        <label className="block text-[11.5px] tracking-[0.16em] font-medium mb-2.5" style={{ color: 'var(--muted)' }}>
+        <label
+          htmlFor={searchId}
+          className="block text-[11.5px] tracking-[0.16em] font-medium mb-2.5"
+          style={{ color: 'var(--muted)' }}
+        >
           {t('jobField')}
         </label>
         {showDisplay && occ && (
@@ -122,7 +130,8 @@ export default function JobCard({
               type="button"
               onClick={(e) => { e.stopPropagation(); onPatch({ anzsco: '' }); onUIPatch({ open: false, q: '' }); }}
               title={t('clearOcc')}
-              className="cursor-pointer text-[15px] px-3 hover:text-[var(--danger)]"
+              aria-label={t('clearOcc')}
+              className="cursor-pointer text-[15px] px-4 hover:text-[var(--danger)]"
               style={{ background: 'none', border: 'none', borderLeft: '1px solid var(--hair)', color: 'var(--muted)' }}
             >
               ×
@@ -131,6 +140,11 @@ export default function JobCard({
         )}
         {showSearch && (
           <input
+            id={searchId}
+            role="combobox"
+            aria-expanded={ui.open}
+            aria-controls={ui.open ? searchListId : undefined}
+            aria-autocomplete="list"
             value={ui.q}
             onChange={(e) => onUIPatch({ q: e.target.value, open: true })}
             onFocus={() => onUIPatch({ open: true })}
@@ -147,19 +161,23 @@ export default function JobCard({
         )}
         {ui.open && (
           <div
+            id={searchListId}
+            role="listbox"
             className="absolute z-50 left-0 right-0 max-h-[296px] overflow-auto"
             style={{
               top: 'calc(100% + 6px)',
               background: 'var(--surface)',
               border: '1px solid var(--hair)',
               boxShadow: 'var(--shadow)',
-              animation: 'eoiDropIn 0.18s ease both',
+              animation: 'eoiDropIn 0.18s ease backwards',
             }}
           >
             {filtered.slice(0, MAX_RESULTS).map((o) => (
               <button
                 key={o.anzsco}
                 type="button"
+                role="option"
+                aria-selected={job.anzsco === o.anzsco}
                 onClick={() => { onPatch({ anzsco: o.anzsco }); onUIPatch({ open: false, q: '' }); }}
                 className="grid items-baseline gap-3 w-full px-3.5 py-3 cursor-pointer text-[13px] text-left leading-[1.45] hover:bg-[var(--hover)]"
                 style={{
@@ -188,7 +206,7 @@ export default function JobCard({
         )}
       </div>
 
-      <div className="grid gap-x-7 gap-y-[22px] mt-[22px]" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))' }}>
+      <div className="grid gap-x-7 gap-y-[22px] mt-[22px]" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(240px, 100%), 1fr))' }}>
         {SELECT_FIELDS.map((field) => {
           const key = `${job.id}:${field}`;
           return (

--- a/src/components/ReferenceSection.tsx
+++ b/src/components/ReferenceSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import SectionHeading from './SectionHeading';
@@ -15,16 +15,20 @@ interface ReferenceSectionProps {
 
 function Collapsible({ title, children }: { title: string; children: ReactNode }) {
   const [open, setOpen] = useState(false);
+  const contentId = useId();
   return (
     <div style={{ borderBottom: '1px solid var(--hair)' }}>
       <button
         type="button"
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-controls={contentId}
         className="w-full flex justify-between items-center gap-3.5 py-[18px] cursor-pointer text-left hover:text-[var(--muted)]"
         style={{ background: 'none', border: 'none', color: 'inherit' }}
       >
         <span className="text-[17px]" style={{ fontFamily: 'var(--font-serif)' }}>{title}</span>
         <span
+          aria-hidden="true"
           className="text-lg font-light leading-none"
           style={{ color: 'var(--muted)', transition: 'transform 0.35s ease', transform: open ? 'rotate(45deg)' : 'rotate(0deg)' }}
         >
@@ -32,6 +36,9 @@ function Collapsible({ title, children }: { title: string; children: ReactNode }
         </span>
       </button>
       <div
+        id={contentId}
+        // Clipped content must also leave the tab order and accessibility tree
+        inert={!open}
         className="grid"
         style={{ gridTemplateRows: open ? '1fr' : '0fr', transition: 'grid-template-rows 0.45s cubic-bezier(0.22, 1, 0.36, 1)' }}
       >
@@ -49,7 +56,7 @@ export default function ReferenceSection({ totalPoints, evaluation }: ReferenceS
   const jobsWithOcc = evaluation.jobs.filter((je) => je.occupation);
 
   return (
-    <section className="mt-[72px]" style={{ animation: 'eoiFadeUp 0.7s ease 0.3s both' }}>
+    <section className="mt-[72px]" style={{ animation: 'eoiFadeUp 0.7s ease 0.3s backwards' }}>
       <SectionHeading num="04" title={t('sections.reference')} side="REFERENCE" />
 
       <div className="mt-[18px]">
@@ -138,7 +145,7 @@ export default function ReferenceSection({ totalPoints, evaluation }: ReferenceS
                   href={s.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-[11.5px] tracking-[0.08em] underline underline-offset-4 whitespace-nowrap hover:text-[var(--ink)]"
+                  className="text-[11.5px] tracking-[0.08em] underline underline-offset-4 whitespace-nowrap py-2 -my-2 hover:text-[var(--ink)]"
                   style={{ color: 'var(--muted)', textDecorationColor: 'var(--hair)' }}
                 >
                   {t('visit')}&nbsp;↗

--- a/src/components/ResultsBand.tsx
+++ b/src/components/ResultsBand.tsx
@@ -102,10 +102,10 @@ export default function ResultsBand({
     .map((k) => ({ key: k, label: t(`bd.${k}`), value: evaluation.shared[k] }));
 
   const suggestions = suggestionsFor(evaluation, shared, goal);
-  const progressPct = `${Math.min((displayTotal / goal) * 100, 100).toFixed(1)}%`;
+  const progressScale = Math.min(displayTotal / goal, 1);
 
   return (
-    <section className="mt-[72px]" style={{ animation: 'eoiFadeUp 0.7s ease 0.24s both' }}>
+    <section className="mt-[72px]" style={{ animation: 'eoiFadeUp 0.7s ease 0.24s backwards' }}>
       <SectionHeading num="03" title={t('sections.result')} side="RESULT" />
 
       <div
@@ -147,8 +147,13 @@ export default function ResultsBand({
 
         <div className="mt-[26px] h-0.5 relative" style={{ background: 'var(--band-hair)' }}>
           <div
-            className="absolute top-0 bottom-0 left-0"
-            style={{ width: progressPct, background: 'var(--band-ink)', transition: 'width 0.7s cubic-bezier(0.22, 1, 0.36, 1)' }}
+            className="absolute inset-0"
+            style={{
+              background: 'var(--band-ink)',
+              transform: `scaleX(${progressScale})`,
+              transformOrigin: 'left',
+              transition: 'transform 0.7s cubic-bezier(0.22, 1, 0.36, 1)',
+            }}
           />
         </div>
 
@@ -161,7 +166,7 @@ export default function ResultsBand({
                 type="button"
                 onClick={onGoalDec}
                 aria-label="Decrease goal"
-                className="w-7 h-[26px] cursor-pointer text-sm leading-none p-0 hover:bg-[var(--band-hair-soft)]"
+                className="w-9 h-8 cursor-pointer text-sm leading-none p-0 hover:bg-[var(--band-hair-soft)]"
                 style={{ background: 'none', border: 'none', color: 'var(--band-soft)' }}
               >
                 −
@@ -176,7 +181,7 @@ export default function ResultsBand({
                 type="button"
                 onClick={onGoalInc}
                 aria-label="Increase goal"
-                className="w-7 h-[26px] cursor-pointer text-sm leading-none p-0 hover:bg-[var(--band-hair-soft)]"
+                className="w-9 h-8 cursor-pointer text-sm leading-none p-0 hover:bg-[var(--band-hair-soft)]"
                 style={{ background: 'none', border: 'none', color: 'var(--band-soft)' }}
               >
                 +

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -13,10 +13,10 @@ export default function SectionHeading({ num, title, side }: SectionHeadingProps
       style={{ borderTop: '1px solid var(--ink)' }}
     >
       <div className="flex items-baseline gap-3.5">
-        <span className="text-[13px]" style={{ fontFamily: 'var(--font-serif)', color: 'var(--muted)' }}>
+        <span aria-hidden="true" className="text-[13px]" style={{ fontFamily: 'var(--font-serif)', color: 'var(--muted)' }}>
           {num}
         </span>
-        <span className="text-[12.5px] font-medium tracking-[0.2em]">{title}</span>
+        <h2 className="m-0 text-[12.5px] font-medium tracking-[0.2em]">{title}</h2>
       </div>
       <span className="text-[10.5px] tracking-[0.18em]" style={{ color: 'var(--muted)' }}>
         {side}

--- a/src/components/SelectField.tsx
+++ b/src/components/SelectField.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useId, useRef } from 'react';
+
 export interface SelectOption {
   value: string;
   label: string;
@@ -25,11 +27,43 @@ export function pointsTag(points: number): string {
 export default function SelectField({
   label, placeholder, options, value, open, onToggle, onPick, fieldBg = 'surface',
 }: SelectFieldProps) {
+  const id = useId();
+  const labelId = `${id}-label`;
+  const triggerId = `${id}-trigger`;
+  const listId = `${id}-list`;
+  const listRef = useRef<HTMLDivElement | null>(null);
   const selected = options.find((o) => o.value === value && value !== '') ?? null;
+
+  const moveOptionFocus = (delta: number) => {
+    const opts = listRef.current
+      ? Array.from(listRef.current.querySelectorAll<HTMLButtonElement>('[role="option"]'))
+      : [];
+    if (!opts.length) return;
+    const idx = opts.indexOf(document.activeElement as HTMLButtonElement);
+    const next = idx < 0
+      ? (delta > 0 ? 0 : opts.length - 1)
+      : Math.min(Math.max(idx + delta, 0), opts.length - 1);
+    opts[next].focus();
+  };
+
+  const onTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    if (!open) onToggle();
+    // The list renders on the next commit; move focus once it exists
+    requestAnimationFrame(() => moveOptionFocus(e.key === 'ArrowDown' ? 1 : -1));
+  };
+
+  const onListKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    moveOptionFocus(e.key === 'ArrowDown' ? 1 : -1);
+  };
 
   return (
     <div data-dd="true" className="relative">
       <label
+        id={labelId}
         className="block text-[11.5px] tracking-[0.16em] font-medium mb-2.5"
         style={{ color: 'var(--muted)' }}
       >
@@ -37,7 +71,13 @@ export default function SelectField({
       </label>
       <button
         type="button"
+        id={triggerId}
+        aria-labelledby={`${labelId} ${triggerId}`}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={open ? listId : undefined}
         onClick={(e) => { e.stopPropagation(); onToggle(); }}
+        onKeyDown={onTriggerKeyDown}
         className="w-full flex justify-between items-center gap-3 px-3.5 py-[13px] cursor-pointer text-left hover:border-[var(--muted)] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--muted)] focus-visible:outline-offset-2"
         style={{
           background: fieldBg === 'surface' ? 'var(--surface)' : 'var(--bg)',
@@ -66,19 +106,26 @@ export default function SelectField({
       </button>
       {open && (
         <div
+          ref={listRef}
+          id={listId}
+          role="listbox"
+          aria-labelledby={labelId}
+          onKeyDown={onListKeyDown}
           className="absolute z-50 left-0 right-0 max-h-[296px] overflow-auto"
           style={{
             top: 'calc(100% + 6px)',
             background: 'var(--surface)',
             border: '1px solid var(--hair)',
             boxShadow: 'var(--shadow)',
-            animation: 'eoiDropIn 0.18s ease both',
+            animation: 'eoiDropIn 0.18s ease backwards',
           }}
         >
           {options.map((o) => (
             <button
               key={o.value || '_none'}
               type="button"
+              role="option"
+              aria-selected={value === o.value && o.value !== ''}
               onClick={() => onPick(o.value)}
               className="flex w-full justify-between items-baseline gap-4 px-3.5 py-3 cursor-pointer text-[13px] text-left leading-[1.45] hover:bg-[var(--hover)]"
               style={{

--- a/src/components/SharedCriteriaSection.tsx
+++ b/src/components/SharedCriteriaSection.tsx
@@ -31,14 +31,14 @@ export default function SharedCriteriaSection({
   return (
     <section
       className="mt-[76px] relative"
-      style={{ zIndex: zActive ? 30 : 'auto', animation: 'eoiFadeUp 0.7s ease 0.08s both' }}
+      style={{ zIndex: zActive ? 30 : 'auto', animation: 'eoiFadeUp 0.7s ease 0.08s backwards' }}
     >
       <SectionHeading num="01" title={t('sections.shared')} side="SHARED" />
       <p className="mt-3.5 mb-0 text-[12.5px] leading-[1.7] max-w-[46em]" style={{ color: 'var(--muted)' }}>
         {t('sharedNote')}
       </p>
 
-      <div className="grid gap-x-9 gap-y-[30px] mt-[30px]" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(290px, 1fr))' }}>
+      <div className="grid gap-x-9 gap-y-[30px] mt-[30px]" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(290px, 100%), 1fr))' }}>
         {SELECT_FIELDS.map((field) => {
           const key = `sh:${field}`;
           return (
@@ -66,7 +66,7 @@ export default function SharedCriteriaSection({
           <div className="text-[11.5px] tracking-[0.16em] font-medium" style={{ color: 'var(--muted)' }}>
             {t(`groups.${group.id}`)}
           </div>
-          <div className="grid gap-x-9 mt-1.5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(290px, 1fr))' }}>
+          <div className="grid gap-x-9 mt-1.5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(min(290px, 100%), 1fr))' }}>
             {group.items.map((name: SharedBonusField) => (
               <CheckRow
                 key={name}

--- a/src/lib/exportCard.ts
+++ b/src/lib/exportCard.ts
@@ -29,6 +29,8 @@ export interface CardOptions {
   theme: CardTheme;
   labels: CardLabels;
   dateLabel: string;
+  /** Device-pixel multiplier for the canvas backing store (default 2 = 2160×2880 export) */
+  scale?: number;
 }
 
 const SHARED_ROW_ORDER = [
@@ -50,8 +52,12 @@ export async function ensureCardFonts(): Promise<void> {
   ]).catch(() => { /* fall back to system serif */ });
 }
 
-/** Draw the 1080×1440 share card. Colors come from cardThemes, values from the evaluation. */
-export function drawCard({ evaluation, goal, lang, theme, labels, dateLabel }: CardOptions): HTMLCanvasElement {
+/**
+ * Draw the share card. Layout runs in 1080×1440 logical pixels; the canvas
+ * backing store is `scale`× larger so the exported PNG stays crisp on
+ * high-DPI screens. Colors come from cardThemes, values from the evaluation.
+ */
+export function drawCard({ evaluation, goal, lang, theme, labels, dateLabel, scale = 2 }: CardOptions): HTMLCanvasElement {
   const ev = evaluation;
   // Headline number is the bare score (裸分); pathway rows below carry the +5/+15 route totals.
   const total = ev.bareScore;
@@ -59,9 +65,10 @@ export function drawCard({ evaluation, goal, lang, theme, labels, dateLabel }: C
   const W = 1080, H = 1440, P = 96, IW = W - P * 2;
 
   const cv = document.createElement('canvas');
-  cv.width = W;
-  cv.height = H;
+  cv.width = W * scale;
+  cv.height = H * scale;
   const ctx = cv.getContext('2d')!;
+  ctx.scale(scale, scale);
 
   const setLS = (v: string) => {
     try {

--- a/src/lib/urlState.ts
+++ b/src/lib/urlState.ts
@@ -63,6 +63,21 @@ export function readStateFromUrl(): AppState | null {
   return { shared, jobs: jobs.length ? jobs : [newJob()] };
 }
 
+/** State-owned query params; anything else (e.g. i18next's ?lng=) is preserved on rewrite */
+const STATE_PARAM_KEYS = [...Object.keys(SHARED_PARAMS), ...Object.keys(FLAG_PARAMS), 'jobs'];
+
+/**
+ * Rebuild the query string from app state while keeping foreign params intact.
+ * Returns the query string without the leading '?', or '' when empty.
+ */
+export function mergeQueryString(currentSearch: string, shared: SharedCriteria, jobs: JobAssessment[]): string {
+  const params = new URLSearchParams(currentSearch);
+  for (const key of STATE_PARAM_KEYS) params.delete(key);
+  const stateParams = new URLSearchParams(stateToQueryString(shared, jobs));
+  for (const [k, v] of stateParams) params.set(k, v);
+  return params.toString();
+}
+
 export function stateToQueryString(shared: SharedCriteria, jobs: JobAssessment[]): string {
   const params = new URLSearchParams();
   for (const [param, field] of Object.entries(SHARED_PARAMS)) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,7 +17,8 @@
   --hover: #ece8da;
   --ink: #2b2a24;
   --ink-soft: #4a473d;
-  --muted: #8c8674;
+  /* ≥4.5:1 on both --bg and --surface (WCAG AA for the small text this tier carries) */
+  --muted: #6f6a54;
   --hair: #dcd7c6;
   --hair-soft: #e6e1d1;
   --danger: #a5502f;
@@ -50,13 +51,13 @@
   --hover: #2d2b22;
   --ink: #eae6d8;
   --ink-soft: #cfc9b8;
-  --muted: #8f8977;
+  --muted: #98927f;
   --hair: #39362c;
   --hair-soft: #2f2d24;
   --danger: #d89a7e;
   --band-bg: #efecdf;
   --band-ink: #2b2a24;
-  --band-muted: #8d8776;
+  --band-muted: #6f6a58;
   --band-soft: #575347;
   --band-hair: #d5cfbc;
   --band-hair-soft: #e2dcca;
@@ -71,13 +72,13 @@
     --hover: #2d2b22;
     --ink: #eae6d8;
     --ink-soft: #cfc9b8;
-    --muted: #8f8977;
+    --muted: #98927f;
     --hair: #39362c;
     --hair-soft: #2f2d24;
     --danger: #d89a7e;
     --band-bg: #efecdf;
     --band-ink: #2b2a24;
-    --band-muted: #8d8776;
+    --band-muted: #6f6a58;
     --band-soft: #575347;
     --band-hair: #d5cfbc;
     --band-hair-soft: #e2dcca;
@@ -112,7 +113,17 @@ body {
 
 input::placeholder {
   color: inherit;
-  opacity: 0.4;
+  opacity: 0.55;
+}
+
+/* Replace the browser's blue focus halo with a theme-aware ring; keep it keyboard-only */
+.theme-toggle:focus {
+  outline: none;
+}
+
+.theme-toggle:focus-visible {
+  outline: 1px solid var(--muted);
+  outline-offset: 3px;
 }
 
 /* Scrollbar */

--- a/tests/urlState.test.ts
+++ b/tests/urlState.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { mergeQueryString, stateToQueryString } from '@/lib/urlState';
+import type { JobAssessment, SharedCriteria } from '@/lib/types';
+import { defaultSharedCriteria } from '@/lib/types';
+
+function job(overrides: Partial<JobAssessment> = {}): JobAssessment {
+  return { id: 'j1', anzsco: '', ausWork: '', overseasWork: '', professionalYear: false, ...overrides };
+}
+
+function shared(overrides: Partial<SharedCriteria> = {}): SharedCriteria {
+  return { ...defaultSharedCriteria, ...overrides };
+}
+
+describe('stateToQueryString', () => {
+  it('serialises shared criteria and non-empty jobs', () => {
+    const qs = stateToQueryString(
+      shared({ age: '25-32', stem: true }),
+      [job({ anzsco: '261313', ausWork: '3-5' })],
+    );
+    const params = new URLSearchParams(qs);
+    expect(params.get('a')).toBe('25-32');
+    expect(params.get('s')).toBe('1');
+    expect(params.get('jobs')).toBe('261313:3-5::0');
+  });
+
+  it('omits empty jobs entirely', () => {
+    expect(stateToQueryString(shared(), [job()])).toBe('');
+  });
+});
+
+describe('mergeQueryString', () => {
+  it('preserves foreign params such as lng', () => {
+    const qs = mergeQueryString('?lng=zh', shared({ age: '25-32' }), [job()]);
+    const params = new URLSearchParams(qs);
+    expect(params.get('lng')).toBe('zh');
+    expect(params.get('a')).toBe('25-32');
+  });
+
+  it('replaces stale state params instead of stacking them', () => {
+    const qs = mergeQueryString('?a=18-24&jobs=111111:::0', shared({ age: '25-32' }), [job()]);
+    const params = new URLSearchParams(qs);
+    expect(params.get('a')).toBe('25-32');
+    expect(params.get('jobs')).toBeNull();
+  });
+
+  it('drops state params when state is emptied but keeps foreign ones', () => {
+    const qs = mergeQueryString('?lng=zh&a=25-32&jobs=261313:::0', shared(), [job()]);
+    expect(qs).toBe('lng=zh');
+  });
+
+  it('returns an empty string when there is nothing to keep', () => {
+    expect(mergeQueryString('', shared(), [job()])).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the theme-toggle affordance bug, applies all findings from a full site audit (a11y / responsive / performance / theming), and sharpens the exported share card.

### Theme toggle
Both states rendered as the same pale circle (light = transparent fill, dark = cream `--ink` fill) plus the browser's default blue focus halo. Now a half-filled disc (◐ contrast glyph) that rotates 180° on switch, `aria-pressed`, and a theme-aware `:focus-visible` ring.

### Accessibility (audit P1)
- Muted text tiers now meet WCAG AA 4.5:1 in both themes (light `--muted` #6f6a54 · 4.73:1, dark `--muted` #98927f, dark `--band-muted` #6f6a58 · 4.57:1)
- SelectField: `listbox`/`option` roles, `aria-expanded`, label association, arrow-key navigation
- Occupation search: `combobox` pattern + label `htmlFor`
- CheckRow: `checkbox` role + `aria-checked`
- Reference collapsibles: `aria-expanded` + `inert` (collapsed links no longer create 16 invisible tab stops)
- Export modal: `role="dialog"`, `aria-modal`, focus moves in on open, Tab is trapped, focus restored on close
- Section titles are real `h2`s; `<html lang>` follows the active language

### Fixes & hardening (audit P2/P3)
- URL rewrite preserves foreign query params (`?lng=zh` was being wiped) — new `mergeQueryString` + vitest suite
- Service worker: cache rotated to v3, stale-while-revalidate for locales/non-hashed assets — deploys no longer serve stale bundles
- Touch targets ≥24px across remove/clear/goal/lang/theme controls (visuals unchanged)
- No horizontal overflow at 320px (`minmax(min(290px, 100%), 1fr)`)
- Dark `themeColor` variant, progress bar animates `transform`, entry animations use `fill: backwards`

### Export card
Canvas now renders at 2× (2160×2880) so the downloaded PNG stays crisp on high-DPI screens.

## Test plan
- [x] `npm test` — 57/57 (6 new urlState tests)
- [x] `tsc --noEmit` and `next build` pass
- [x] Browser-verified: toggle both states, keyboard select flow (↓↓ + Enter), modal focus trap/restore, `?lng=zh` preserved after state change, `html lang` syncs, 0 touch targets <24px, no 320px overflow, export preview 2160×2880

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v