### PR TITLE
feat: per-occupation timeline series

### DIFF
--- a/src/components/TimelineChart.tsx
+++ b/src/components/TimelineChart.tsx
@@ -12,31 +12,51 @@ interface TimelineChartProps {
   today: string;
 }
 
-// Markers carry only a number; the descriptions live in the event list the
-// section renders below the chart, so labels can never collide again.
-const W = 720, H = 214, PL = 40, PR = 30, TOP = 30, AXIS = 176;
+// One step line per assessment, distinguished by dash pattern (monochrome).
+// Markers carry only a number; descriptions live in the legend below.
+const W = 720, H = 232, PL = 40, PR = 62, TOP = 30, AXIS = 176;
+const DASHES: (string | undefined)[] = [undefined, '7 4', '2 3', '9 3 2 3', '1 4'];
 
 export default function TimelineChart({ timeline, goal, today }: TimelineChartProps) {
   const { t } = useTranslation();
-  const { startScore, events, horizonEnd } = timeline;
+  const { startScore, startBases, events, horizonEnd } = timeline;
 
   const total = Math.max(1, monthsBetween(today, horizonEnd));
   const x = (ym: string) => PL + (monthsBetween(today, ym) / total) * (W - PL - PR);
 
-  const scores = [startScore, ...events.map((e) => e.scoreAfter)];
-  const yMin = Math.min(MIN_POINTS, ...scores) - 8;
-  const yMax = Math.max(goal, ...scores) + 8;
+  const allScores = [...startBases, ...events.flatMap((e) => e.basesAfter), startScore];
+  const yMin = Math.min(MIN_POINTS, ...allScores) - 8;
+  const yMax = Math.max(goal, ...allScores) + 8;
   const y = (s: number) => AXIS - ((s - yMin) / (yMax - yMin)) * (AXIS - TOP);
 
-  // step path: horizontal to each score event, vertical at the event month
-  let d = `M${PL} ${y(startScore)}`;
-  for (const e of events) {
-    if (e.delta === 0) continue;
-    d += ` H${x(e.date)} V${y(e.scoreAfter)}`;
-  }
   const endX = x(horizonEnd);
-  d += ` H${endX}`;
-  const area = `${d} V${AXIS} H${PL} Z`;
+  const single = startBases.length === 1;
+  const endsAt = new Map(events.filter((e) => e.causes.some((c) => c.kind === 'eligibilityEnd')).map((e) => [e.date, true]));
+
+  // Per-assessment step series: path + own change points + final value
+  const series = startBases.map((startBase, i) => {
+    let d = `M${PL} ${y(startBase)}`;
+    let prevBase = startBase;
+    const dots: { ex: number; ey: number; up: boolean }[] = [];
+    for (const e of events) {
+      const b = e.basesAfter[i];
+      if (b !== prevBase) {
+        d += ` H${x(e.date)} V${y(b)}`;
+        dots.push({ ex: x(e.date), ey: y(b), up: b > prevBase });
+        prevBase = b;
+      }
+    }
+    d += ` H${endX}`;
+    return { d, dots, finalBase: prevBase, tag: String.fromCharCode(65 + i) };
+  });
+
+  // End labels ("A 110"): nudge apart when lines converge
+  const endLabels = series
+    .map((s, i) => ({ ...s, i, ly: y(s.finalBase) + 4 }))
+    .sort((a, b) => a.ly - b.ly);
+  for (let i = 1; i < endLabels.length; i++) {
+    if (endLabels[i].ly - endLabels[i - 1].ly < 12) endLabels[i].ly = endLabels[i - 1].ly + 12;
+  }
 
   const years: string[] = [];
   for (let yr = Number(today.slice(0, 4)) + 1; yr <= Number(horizonEnd.slice(0, 4)); yr++) years.push(String(yr));
@@ -56,42 +76,60 @@ export default function TimelineChart({ timeline, goal, today }: TimelineChartPr
         <line x1={PL} y1={y(MIN_POINTS)} x2={W - PR} y2={y(MIN_POINTS)} stroke="var(--hair)" strokeWidth="0.75" strokeDasharray="1 5" />
         <text x={W - PR} y={y(MIN_POINTS) + 14} fontSize="10" fill="var(--muted)" textAnchor="end" letterSpacing="1">{t('tlMinLine', { n: MIN_POINTS })}</text>
 
-        {/* area + step line */}
-        <path d={area} fill="var(--ink)" opacity="0.06" />
-        <path d={d} fill="none" stroke="var(--ink)" strokeWidth="1.75" />
-
-        {/* today hairline + start score */}
+        {/* today hairline + start score (single-assessment only — lines carry it otherwise) */}
         <line x1={PL} y1={TOP} x2={PL} y2={AXIS} stroke="var(--hair)" strokeWidth="1" />
         <text x={PL} y={TOP - 10} fontSize="10" fill="var(--muted)" letterSpacing="2">{t('tlToday')}</text>
-        <text x={PL + 12} y={y(startScore) - 8} fontSize="17" fontFamily="var(--font-serif)" fill="var(--ink)">{startScore}</text>
+        {single && (
+          <text x={PL + 12} y={y(startBases[0]) - 8} fontSize="17" fontFamily="var(--font-serif)" fill="var(--ink)">{startBases[0]}</text>
+        )}
 
-        {/* events: numbered markers — dots for gains/losses, dashed flag for warnings, × for eligibilityEnd */}
+        {/* one step line per assessment */}
+        {series.map((s, i) => (
+          <g key={s.tag}>
+            <path d={s.d} fill="none" stroke="var(--ink)" strokeWidth={1.6} strokeDasharray={DASHES[i % DASHES.length]} />
+            {s.dots.map((dot, k) => (
+              <circle
+                key={k}
+                cx={dot.ex}
+                cy={dot.ey}
+                r="3.5"
+                fill={dot.up ? 'var(--ink)' : 'none'}
+                stroke={dot.up ? 'var(--ink)' : 'var(--danger)'}
+                strokeWidth="1.5"
+              />
+            ))}
+          </g>
+        ))}
+
+        {/* line-end tags + final values */}
+        {endLabels.map((s) => (
+          <text key={s.tag} x={endX + 7} y={s.ly} fontSize="12" fontFamily="var(--font-serif)" fill="var(--ink)">
+            {s.tag}&nbsp;{s.finalBase}
+          </text>
+        ))}
+
+        {/* event markers: warnings as flags, all numbered in the lane below the axis */}
         {events.map((e, i) => {
           const ex = x(e.date);
-          const no = String(i + 1);
-          if (e.warning) {
-            return (
-              <g key={e.date}>
-                <line x1={ex} y1={TOP + 24} x2={ex} y2={AXIS} stroke="var(--danger)" strokeWidth="0.75" strokeDasharray="3 3" />
-                <rect x={ex - 4} y={TOP + 16} width="8" height="8" transform={`rotate(45 ${ex} ${TOP + 20})`} fill="none" stroke="var(--danger)" strokeWidth="1.25" />
-                <text x={ex + 9} y={TOP + 24} fontSize="10" fontFamily="var(--font-serif)" fill="var(--danger)">{no}</text>
-              </g>
-            );
-          }
-          const isEnd = e.causes.some((c) => c.kind === 'eligibilityEnd');
-          const ey = y(e.scoreAfter);
+          const isEnd = endsAt.has(e.date);
+          const danger = e.warning || e.delta < 0 || isEnd;
           return (
             <g key={e.date}>
-              {isEnd ? (
+              {e.warning && (
                 <>
-                  <line x1={ex - 5} y1={ey - 5} x2={ex + 5} y2={ey + 5} stroke="var(--danger)" strokeWidth="1.5" />
-                  <line x1={ex - 5} y1={ey + 5} x2={ex + 5} y2={ey - 5} stroke="var(--danger)" strokeWidth="1.5" />
+                  <line x1={ex} y1={TOP + 24} x2={ex} y2={AXIS} stroke="var(--danger)" strokeWidth="0.75" strokeDasharray="3 3" />
+                  <rect x={ex - 4} y={TOP + 16} width="8" height="8" transform={`rotate(45 ${ex} ${TOP + 20})`} fill="none" stroke="var(--danger)" strokeWidth="1.25" />
                 </>
-              ) : (
-                <circle cx={ex} cy={ey} r="4" fill={e.delta >= 0 ? 'var(--ink)' : 'none'} stroke={e.delta >= 0 ? 'var(--ink)' : 'var(--danger)'} strokeWidth="1.5" />
               )}
-              <text x={ex} y={e.delta >= 0 ? ey - 14 : ey + 24} fontSize="16" fontFamily="var(--font-serif)" fill={e.delta >= 0 ? 'var(--ink)' : 'var(--danger)'} textAnchor="middle">{e.scoreAfter}</text>
-              <text x={ex + 9} y={ey + (e.delta >= 0 ? 12 : -8)} fontSize="10" fontFamily="var(--font-serif)" fill={isEnd || e.delta < 0 ? 'var(--danger)' : 'var(--muted)'}>{no}</text>
+              {isEnd && series.map((s) => (
+                <g key={s.tag}>
+                  <line x1={ex - 5} y1={y(e.basesAfter[series.indexOf(s)]) - 5} x2={ex + 5} y2={y(e.basesAfter[series.indexOf(s)]) + 5} stroke="var(--danger)" strokeWidth="1.5" />
+                  <line x1={ex - 5} y1={y(e.basesAfter[series.indexOf(s)]) + 5} x2={ex + 5} y2={y(e.basesAfter[series.indexOf(s)]) - 5} stroke="var(--danger)" strokeWidth="1.5" />
+                </g>
+              ))}
+              <text x={ex} y={AXIS + 15} fontSize="10.5" fontFamily="var(--font-serif)" textAnchor="middle" fill={danger ? 'var(--danger)' : 'var(--muted)'}>
+                {i + 1}
+              </text>
             </g>
           );
         })}
@@ -99,7 +137,7 @@ export default function TimelineChart({ timeline, goal, today }: TimelineChartPr
         {/* axis + year ticks */}
         <line x1={PL} y1={AXIS} x2={W - PR} y2={AXIS} stroke="var(--ink)" strokeWidth="1" />
         {years.map((yr) => (
-          <text key={yr} x={x(`${yr}-01`)} y={H - 22} fontSize="9.5" fill="var(--muted)" opacity="0.7" textAnchor="middle">{yr}</text>
+          <text key={yr} x={x(`${yr}-01`)} y={H - 4} fontSize="9.5" fill="var(--muted)" opacity="0.7" textAnchor="middle">{yr}</text>
         ))}
       </svg>
     </div>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -62,7 +62,7 @@ export default function TimelineSection({
                       <span className="text-xs tabular-nums" style={{ color: danger ? 'var(--danger)' : 'var(--muted)' }}>{e.date}</span>
                       <span className="leading-[1.55] min-w-0" style={{ color: danger ? 'var(--danger)' : 'var(--ink)' }}>{label}</span>
                       <span className="text-[13px] tabular-nums" style={{ fontFamily: 'var(--font-serif)', color: danger ? 'var(--danger)' : 'var(--ink)' }}>
-                        {e.warning ? '⚠' : `${e.delta > 0 ? '+' : ''}${e.delta}`}
+                        {e.warning ? '⚠' : e.delta === 0 ? '±0' : `${e.delta > 0 ? '+' : ''}${e.delta}`}
                       </span>
                       <span className="text-[14px] tabular-nums text-right min-w-8" style={{ fontFamily: 'var(--font-serif)' }}>
                         {e.warning ? '' : e.scoreAfter}

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -99,13 +99,17 @@ export interface TimelineCause {
 export interface TimelineEvent {
   date: string;                           // YYYY-MM
   causes: TimelineCause[];
-  delta: number;                          // score change this month (0 for pure warnings)
+  delta: number;                          // bare-score change this month (0 for pure warnings)
   scoreAfter: number;                     // bare score after this month
+  /** Per-assessment base scores after this month (index-aligned with jobs) */
+  basesAfter: number[];
   warning: boolean;                       // true when every cause is an expiry
 }
 
 export interface TimelineResult {
   startScore: number;
+  /** Per-assessment base scores today (index-aligned with jobs) */
+  startBases: number[];
   events: TimelineEvent[];
   horizonEnd: string;                     // YYYY-MM
   endsAt45: boolean;
@@ -260,34 +264,40 @@ export function buildTimeline({
     });
   }
 
-  // Compute bare score at an arbitrary month, applying date-derived brackets.
-  const scoreAt = (m: string): number => {
+  // Per-assessment base scores (and the bare max) at an arbitrary month.
+  const basesAt = (m: string): { bases: number[]; bare: number } => {
     const { shared: s, jobs: js } = applyDates(shared, jobs, dates, m);
-    return evaluate(s, js).bareScore;
+    const ev = evaluate(s, js);
+    return { bases: ev.jobs.map((je) => je.base), bare: ev.bareScore };
   };
 
-  const startScore = scoreAt(today);
+  const start = basesAt(today);
+  const startScore = start.bare;
+  const startBases = start.bases;
 
-  // Build events: sort ascending by month, compute deltas, then filter to only
-  // months that change the score, carry a warning, or mark the eligibility end.
-  let prev = startScore;
-  const events: TimelineEvent[] = [...causesByMonth.entries()]
-    .sort(([a], [b]) => monthsBetween(b, a))   // ascending: monthsBetween(b, a) = toN(a) − toN(b)
-    .map(([date, causes]) => {
-      const scoreAfter = scoreAt(date);
-      const delta = scoreAfter - prev;
-      prev = scoreAfter;
-      const warning = causes.every((c) => WARNING_KINDS.has(c.kind));
-      return { date, causes, delta, scoreAfter, warning };
-    })
-    .filter(
-      (e) =>
-        e.delta !== 0 ||
-        e.warning ||
-        e.causes.some((c) => c.kind === 'eligibilityEnd') ||
-        // Keep multi-cause months even when changes cancel (e.g., age-drop + work gain).
-        e.causes.length > 1,
-    );
+  // Build events: sort ascending by month, compute per-assessment bases, then
+  // keep months where ANY assessment's base moves (so every occupation's line
+  // bends where it should), plus warnings and the eligibility end.
+  let prevBare = startScore;
+  let prevBases = startBases;
+  const events: TimelineEvent[] = [];
+  for (const [date, causes] of [...causesByMonth.entries()]
+    .sort(([a], [b]) => monthsBetween(b, a))) { // ascending: monthsBetween(b, a) = toN(a) − toN(b)
+    const { bases, bare } = basesAt(date);
+    const delta = bare - prevBare;
+    const anyBaseMoved = bases.some((b, i) => b !== prevBases[i]);
+    const warning = causes.every((c) => WARNING_KINDS.has(c.kind));
+    const keep = anyBaseMoved || warning
+      || causes.some((c) => c.kind === 'eligibilityEnd')
+      // Multi-cause months can cancel to zero on every base (age −5 + work +5)
+      // yet still deserve a marker.
+      || causes.length > 1;
+    if (keep) {
+      events.push({ date, causes, delta, scoreAfter: bare, basesAfter: bases, warning });
+    }
+    prevBare = bare;
+    prevBases = bases;
+  }
 
-  return { startScore, events, horizonEnd, endsAt45 };
+  return { startScore, startBases, events, horizonEnd, endsAt45 };
 }

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -207,3 +207,31 @@ describe('10-year work window', () => {
     expect(m?.delta).toBe(5);
   });
 });
+
+describe('per-assessment series', () => {
+  const today = '2026-07';
+
+  it('exposes startBases and basesAfter per assessment', () => {
+    const strong = job({ ausWork: '8-10' });                        // base stays flat
+    const weak = job({ anzsco: '233211', ausWorkStart: '2026-01' }); // gains milestones
+    const r = buildTimeline({ shared: shared(), jobs: [strong, weak], dates: dates(), today });
+    expect(r.startBases).toHaveLength(2);
+    expect(r.startBases[0]).toBeGreaterThan(r.startBases[1]);
+    // weak job's 1-year milestone is kept even though the max never moves
+    const m = r.events.find((e) => e.causes.some((c) => c.kind === 'ausWork'));
+    expect(m?.date).toBe('2027-01');
+    expect(m?.delta).toBe(0);                                        // bare max unchanged
+    expect(m?.basesAfter[1]).toBe(r.startBases[1] + 5);              // but B's line bends
+    expect(m?.basesAfter[0]).toBe(r.startBases[0]);
+  });
+
+  it('age events move every assessment base', () => {
+    const r = buildTimeline({
+      shared: shared(), jobs: [job(), job({ anzsco: '233211' })],
+      dates: dates({ birth: '1995-03' }), today,
+    });
+    const drop = r.events.find((e) => e.causes.some((c) => c.kind === 'age'));
+    expect(drop?.basesAfter[0]).toBe(r.startBases[0] - 5);
+    expect(drop?.basesAfter[1]).toBe(r.startBases[1] - 5);
+  });
+});


### PR DESCRIPTION
## Summary

The projection chart drew a single line (bare max) — with several assessments, each occupation's own trajectory was invisible. Now:

- Engine exposes `startBases` / per-event `basesAfter` (index-aligned per assessment); events are kept whenever ANY assessment's base moves, not only the max.
- Chart renders one step line per assessment — monochrome dash variants, per-line change dots, line-end `A 95` labels with collision nudging; event numbers move to a lane under the axis; eligibility-end × marks every line.
- Legend shows `±0` when a line bends without moving the bare max.

## Test plan
- [x] 106/106 vitest (new: startBases/basesAfter shape, kept ±0 events bend the right line, age events move every base)
- [x] tsc + next build
- [x] Browser: 3 assessments → 3 dash-distinct lines, correct final values (95/90/95), per-job legend rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v