### PR TITLE
feat: series key mapping chart tags to occupations

### DIFF
--- a/src/components/TimelineChart.tsx
+++ b/src/components/TimelineChart.tsx
@@ -13,6 +13,8 @@ interface TimelineChartProps {
   today: string;
   /** Legend-row hover: bolds the matching marker and shows its crosshair */
   focusEventIndex?: number | null;
+  /** Occupation names per assessment (index-aligned) for the series key */
+  seriesLabels?: string[];
 }
 
 // One step line per assessment (monochrome dash variants). Numbers live in a
@@ -21,7 +23,7 @@ const W = 720, H = 238, PL = 40, PR = 62, TOP = 30, AXIS = 182;
 const DASHES: (string | undefined)[] = [undefined, '7 4', '2 3', '9 3 2 3', '1 4'];
 const DIM = 0.24;
 
-export default function TimelineChart({ timeline, goal, today, focusEventIndex = null }: TimelineChartProps) {
+export default function TimelineChart({ timeline, goal, today, focusEventIndex = null, seriesLabels }: TimelineChartProps) {
   const { t } = useTranslation();
   const { startScore, startBases, events, horizonEnd } = timeline;
   const [hoverM, setHoverM] = useState<number | null>(null);   // months from today
@@ -120,7 +122,29 @@ export default function TimelineChart({ timeline, goal, today, focusEventIndex =
   const lineOpacity = (i: number) => (focusLine === null || focusLine === i ? 1 : DIM);
 
   return (
-    <div className="mt-[26px] overflow-x-auto">
+    <div className="mt-[26px]">
+      {/* Series key: which occupation each line style belongs to */}
+      <div className="flex flex-wrap gap-x-6 gap-y-1.5 mb-3" onMouseLeave={() => setFocusLine(null)}>
+        {series.map((s, i) => (
+          <button
+            key={s.tag}
+            type="button"
+            onMouseEnter={() => setFocusLine(i)}
+            onFocus={() => setFocusLine(i)}
+            className="flex items-center gap-2 p-0 cursor-default text-left"
+            style={{ background: 'none', border: 'none', opacity: lineOpacity(i), transition: 'opacity 0.2s ease' }}
+          >
+            <svg width="24" height="6" aria-hidden="true">
+              <line x1="0" y1="3" x2="24" y2="3" stroke="var(--ink)" strokeWidth="1.6" strokeDasharray={DASHES[i % DASHES.length]} />
+            </svg>
+            <span className="text-[13px] leading-none" style={{ fontFamily: 'var(--font-serif)' }}>{s.tag}</span>
+            <span className="text-[12px] leading-none" style={{ color: 'var(--ink-soft)' }}>
+              {seriesLabels?.[i] ?? ''}
+            </span>
+          </button>
+        ))}
+      </div>
+      <div className="overflow-x-auto">
       <svg
         viewBox={`0 0 ${W} ${H}`}
         role="img"
@@ -263,6 +287,7 @@ export default function TimelineChart({ timeline, goal, today, focusEventIndex =
           </g>
         )}
       </svg>
+      </div>
     </div>
   );
 }

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -8,6 +8,7 @@ import type { TimelineResult } from '@/lib/timeline';
 import TimelineChart from './TimelineChart';
 import type { JobAssessment, PlanningDates } from '@/lib/types';
 import { isYm } from '@/lib/types';
+import { findOccupation } from '@/lib/points';
 
 interface TimelineSectionProps {
   /** Read-only: all dates are edited next to their source fields (01 / 02) */
@@ -21,9 +22,15 @@ interface TimelineSectionProps {
 export default function TimelineSection({
   dates, jobs, timeline, goal, today,
 }: TimelineSectionProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language?.startsWith('zh') ? 'zh' : 'en';
   // Hovering a legend row highlights the matching marker on the chart
   const [focusEvent, setFocusEvent] = useState<number | null>(null);
+
+  const seriesLabels = jobs.map((j) => {
+    const occ = findOccupation(j.anzsco);
+    return occ ? (lang === 'zh' ? occ.zh : occ.en) : t('noOccName');
+  });
 
   const hasAnyDate = isYm(dates.birth) || isYm(dates.englishTest)
     || jobs.some((j) => isYm(j.ausWorkStart) || isYm(j.overseasWorkStart) || isYm(j.assessmentDate));
@@ -45,7 +52,7 @@ export default function TimelineSection({
         <>
           {hasAnyDate && timeline.events.length > 0 && (
             <>
-              <TimelineChart timeline={timeline} goal={goal} today={today} focusEventIndex={focusEvent} />
+              <TimelineChart timeline={timeline} goal={goal} today={today} focusEventIndex={focusEvent} seriesLabels={seriesLabels} />
               {/* Event legend: numbers match the chart markers; identical causes
                   across assessments are merged with their tags (A · B · C). */}
               <ol className="m-0 mt-2 p-0 list-none" onMouseLeave={() => setFocusEvent(null)}>


### PR DESCRIPTION
## Summary

Section 04 used A/B/C everywhere (lines, tooltip, end labels, legend) with no visible mapping to occupations. Adds a series key above the chart — dash sample + tag + occupation name per assessment — with hover highlighting the corresponding line (same dim behaviour as line hover).

## Test plan
- [x] 106/106 vitest, tsc, build
- [x] Browser: key renders `— A 软件工程师 / – – B 管理顾问 / ⋯ C 土木工程师` with matching dash samples; hovering B dims A/C to 0.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v