### PR TITLE
fix: one compact results band on every breakpoint

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -260,28 +260,11 @@ const PageContent = () => {
           </section>
         </div>
 
-        {/* Mobile / narrow: the full results band in document order (01·02·03·04) */}
-        <div className="min-w-0 wide:hidden">
-          <ResultsBand
-            evaluation={evaluation}
-            shared={shared}
-            goal={goalPoints}
-            displayTotal={displayTotal}
-            onGoalDec={() => setGoalPoints((prev: number) => Math.max(GOAL_RANGE.min, prev - GOAL_RANGE.step))}
-            onGoalInc={() => setGoalPoints((prev: number) => Math.min(GOAL_RANGE.max, prev + GOAL_RANGE.step))}
-            onOpenExport={() => setExportOpen(true)}
-            onCopyLink={handleCopyLink}
-            copied={copied}
-            onReset={handleReset}
-            bandRef={bandRef}
-          />
-        </div>
-
-        {/* Wide screens: compact sticky panel — short enough to fit without inner scroll */}
-        <div className="min-w-0 hidden wide:block wide:col-start-2 wide:row-start-1 wide:row-span-2">
+        {/* One compact results band everywhere: in document order on narrow
+            screens, a sticky right panel on wide ones. */}
+        <div className="min-w-0 wide:col-start-2 wide:row-start-1 wide:row-span-2">
           <div className="wide:sticky wide:top-5">
             <ResultsBand
-              variant="panel"
               evaluation={evaluation}
               shared={shared}
               goal={goalPoints}
@@ -292,6 +275,7 @@ const PageContent = () => {
               onCopyLink={handleCopyLink}
               copied={copied}
               onReset={handleReset}
+              bandRef={bandRef}
             />
           </div>
         </div>

--- a/src/components/ResultsBand.tsx
+++ b/src/components/ResultsBand.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import type { RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import SectionHeading from './SectionHeading';
-import { occupationDisplayName } from './JobCard';
 import type { Evaluation, PathwayResult } from '@/lib/points';
 import type { SharedCriteria } from '@/lib/types';
 import { suggestionsFor } from '@/lib/suggestions';
@@ -22,14 +21,11 @@ interface ResultsBandProps {
   copied: boolean;
   onReset: () => void;
   bandRef?: RefObject<HTMLDivElement | null>;
-  /** 'panel' = compact sticky-sidebar variant for the wide layout */
-  variant?: 'full' | 'panel';
 }
 
 const SHARED_ROW_ORDER = [
   'age', 'english', 'education', 'stem', 'ausStudy', 'regionalStudy', 'communityLanguage', 'partnerStatus',
 ] as const;
-const JOB_ROW_ORDER = ['ausWork', 'overseasWork', 'professionalYear'] as const;
 
 interface PathPresentation {
   statusKey: string;
@@ -76,14 +72,16 @@ function presentPath(p: PathwayResult): PathPresentation {
   };
 }
 
+/**
+ * Compact results band — the single results view on every breakpoint:
+ * inline on narrow screens, the sticky right panel on wide ones.
+ */
 export default function ResultsBand({
   evaluation, shared, goal, displayTotal,
   onGoalDec, onGoalInc, onOpenExport, onCopyLink, copied, onReset, bandRef,
-  variant = 'full',
 }: ResultsBandProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language?.startsWith('zh') ? 'zh' : 'en';
-  const panel = variant === 'panel';
   const [showBreakdown, setShowBreakdown] = useState(false);
 
   // Headline reflects the bare score (裸分); per-pathway rows below show the
@@ -91,9 +89,8 @@ export default function ResultsBand({
   const total = evaluation.bareScore;
 
   let statusLine: string;
-  let warnColor = 'var(--band-muted)';
   if (total >= goal && total > 0) statusLine = t('statusOk');
-  else if (total < MIN_POINTS) { statusLine = t('statusBelowMin', { n: MIN_POINTS - total }); warnColor = 'var(--band-danger)'; }
+  else if (total < MIN_POINTS) statusLine = t('statusBelowMin', { n: MIN_POINTS - total });
   else statusLine = t('statusMin', { n: goal - total });
 
   let bestPathLine = t('noBestPath');
@@ -111,7 +108,7 @@ export default function ResultsBand({
   const progressScale = Math.min(displayTotal / goal, 1);
 
   return (
-    <section className={panel ? 'mt-[72px] wide:mt-[76px]' : 'mt-[72px]'} style={{ animation: 'eoiFadeUp 0.7s ease 0.24s backwards' }}>
+    <section className="mt-[72px] wide:mt-[76px]" style={{ animation: 'eoiFadeUp 0.7s ease 0.24s backwards' }}>
       <SectionHeading num="03" title={t('sections.result')} side="RESULT" />
 
       <div
@@ -121,16 +118,16 @@ export default function ResultsBand({
           background: 'var(--band-bg)',
           color: 'var(--band-ink)',
           border: '1px solid var(--band-border)',
-          padding: panel ? '24px 24px 20px' : 'clamp(26px, 5vw, 46px)',
+          padding: '24px 24px 20px',
           transition: 'background 0.4s ease, color 0.4s ease',
         }}
       >
         <div className="flex justify-between items-end gap-5 flex-wrap">
-          <div className="flex flex-col gap-2.5">
+          <div className="flex flex-col gap-2.5 min-w-0">
             <span className="text-[11.5px] tracking-[0.22em] font-medium" style={{ color: 'var(--band-muted)' }}>
               {t('totalCaps')}
             </span>
-            <span className={panel ? 'text-[13.5px]' : 'text-[15px]'} style={{ fontFamily: 'var(--font-serif)', color: 'var(--band-ink)' }}>
+            <span className="text-[13.5px]" style={{ fontFamily: 'var(--font-serif)', color: 'var(--band-ink)' }}>
               {bestPathLine}
             </span>
             <span className="text-[13px]" style={{ color: 'var(--band-soft)' }}>{statusLine}</span>
@@ -140,7 +137,7 @@ export default function ResultsBand({
               className="font-light tabular-nums"
               style={{
                 fontFamily: 'var(--font-serif)',
-                fontSize: panel ? '62px' : 'clamp(64px, 11vw, 92px)',
+                fontSize: '62px',
                 lineHeight: 0.95,
                 letterSpacing: '-0.02em',
               }}
@@ -196,11 +193,7 @@ export default function ResultsBand({
           </div>
         </div>
 
-        {!panel && total < goal && (
-          <p className="mt-5 mb-0 text-[13px] leading-[1.6]" style={{ color: warnColor }}>{statusLine}</p>
-        )}
-
-        {panel && sharedRows.length > 0 && (
+        {sharedRows.length > 0 && (
           <div className="mt-5" style={{ borderTop: '1px solid var(--band-hair)' }}>
             <button
               type="button"
@@ -212,169 +205,57 @@ export default function ResultsBand({
               {t('sharedCaps')}
               <span aria-hidden="true" className="text-[14px] font-light leading-none" style={{ transition: 'transform 0.3s ease', transform: showBreakdown ? 'rotate(45deg)' : 'none' }}>+</span>
             </button>
-            {showBreakdown && sharedRows.map((r) => (
-              <div
-                key={r.key}
-                className="flex justify-between items-baseline gap-4 py-[7px] text-[12.5px]"
-                style={{ borderTop: '1px solid var(--band-hair-soft)' }}
-              >
-                <span style={{ color: 'var(--band-soft)' }}>{r.label}</span>
-                <span className="text-[13.5px] tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{r.value}</span>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {!panel && sharedRows.length > 0 && (
-          <div className="mt-[30px]" style={{ borderTop: '1px solid var(--band-hair)' }}>
-            <div className="pt-4 pb-1.5 text-[11.5px] tracking-[0.22em] font-medium" style={{ color: 'var(--band-muted)' }}>
-              {t('sharedCaps')}
-            </div>
-            {sharedRows.map((r) => (
-              <div
-                key={r.key}
-                className="flex justify-between items-baseline gap-4 py-2.5 text-[13.5px]"
-                style={{ borderBottom: '1px solid var(--band-hair-soft)' }}
-              >
-                <span style={{ color: 'var(--band-soft)' }}>{r.label}</span>
-                <span className="text-[15px] font-medium tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>
-                  {r.value}
-                </span>
-              </div>
-            ))}
-            <div className="flex justify-between items-baseline gap-4 py-[11px] text-[13px]">
-              <span style={{ color: 'var(--band-muted)' }}>{t('sharedSubtotal')}</span>
-              <span className="text-base font-medium tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>
-                {evaluation.sharedTotal}
-              </span>
-            </div>
-          </div>
-        )}
-
-        {panel && (
-          <div className="mt-4" style={{ borderTop: '1px solid var(--band-hair)' }}>
-            {evaluation.jobs.map((je) => (
-              <div key={je.job.id} className="pt-3 pb-2.5" style={{ borderBottom: '1px solid var(--band-hair-soft)' }}>
-                <div className="flex justify-between items-baseline gap-3">
-                  <span className="min-w-0 flex items-baseline gap-2.5">
-                    <span className="text-[15px] flex-none" style={{ fontFamily: 'var(--font-serif)' }}>
-                      {String.fromCharCode(65 + je.index)}
-                    </span>
-                    <span className="text-[12.5px] overflow-hidden text-ellipsis whitespace-nowrap" style={{ color: 'var(--band-ink)' }}>
-                      {je.occupation ? (lang === 'zh' ? je.occupation.zh : je.occupation.en) : t('noOccName')}
-                    </span>
-                  </span>
-                  <span className="flex-none text-[14px] tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{je.base}</span>
-                </div>
-                <div className="flex gap-4 mt-1.5">
-                  {je.pathways.map((p) => {
-                    const pres = presentPath(p);
-                    return (
-                      <span key={p.code} className="flex items-center gap-1.5 text-[11.5px] tabular-nums" style={{ color: pres.statusColor }}>
-                        <span className="w-[6px] h-[6px] rounded-full flex-none" style={{ border: `1px solid ${pres.dotBorder}`, background: pres.dotBg }} />
-                        {p.code}&nbsp;{pres.totalText}
-                      </span>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {!panel && evaluation.jobs.map((je) => (
-          <div key={je.job.id} className="mt-[26px] px-[22px] pt-5 pb-2" style={{ border: '1px solid var(--band-hair)' }}>
-            <div className="flex justify-between items-baseline gap-3.5 flex-wrap">
-              <div className="flex items-baseline gap-3 min-w-0">
-                <span className="text-lg" style={{ fontFamily: 'var(--font-serif)' }}>
-                  {String.fromCharCode(65 + je.index)}
-                </span>
-                <span className="text-[13.5px] leading-[1.4]" style={{ color: 'var(--band-ink)' }}>
-                  {je.occupation ? occupationDisplayName(je.occupation, lang) : t('noOccName')}
-                </span>
-                {je.occupation && (
-                  <span
-                    className="flex-none text-[10px] tracking-[0.1em]"
-                    style={{ color: 'var(--band-muted)', border: '1px solid var(--band-hair)', padding: '2px 7px' }}
-                  >
-                    {je.occupation.list}
-                  </span>
-                )}
-              </div>
-              <span className="text-xs" style={{ color: 'var(--band-muted)' }}>
-                {t('jobBase')}&nbsp;
-                <span className="text-[15px] tabular-nums" style={{ fontFamily: 'var(--font-serif)', color: 'var(--band-ink)' }}>
-                  {je.base}
-                </span>
-              </span>
-            </div>
-
-            {JOB_ROW_ORDER.filter((k) => je.points[k] > 0).map((k) => (
-              <div
-                key={k}
-                className="flex justify-between items-baseline gap-4 pt-[9px] pb-2 text-[13px]"
-                style={{ borderTop: '1px solid var(--band-hair-soft)' }}
-              >
-                <span style={{ color: 'var(--band-soft)' }}>{t(`bd.${k}`)}</span>
-                <span className="text-sm tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{je.points[k]}</span>
-              </div>
-            ))}
-
-            <div className="mt-2.5" style={{ borderTop: '1px solid var(--band-hair)' }}>
-              {je.pathways.map((p) => {
-                const pres = presentPath(p);
-                return (
+            {showBreakdown && (
+              <>
+                {sharedRows.map((r) => (
                   <div
-                    key={p.code}
-                    className="grid items-baseline gap-3 py-[11px] text-[13px]"
-                    style={{ gridTemplateColumns: '46px 1fr auto auto', borderBottom: '1px solid var(--band-hair-soft)' }}
+                    key={r.key}
+                    className="flex justify-between items-baseline gap-4 py-[7px] text-[12.5px]"
+                    style={{ borderTop: '1px solid var(--band-hair-soft)' }}
                   >
-                    <span className="text-base tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{p.code}</span>
-                    <span className="min-w-0">
-                      <span className="text-xs" style={{ color: 'var(--band-muted)' }}>
-                        {t(`pathNoteByCode.${p.code}`)}
-                      </span>
-                      {p.states.length > 0 && (
-                        <span className="flex flex-wrap gap-1 mt-1.5">
-                          {p.states.map((s) => (
-                            <span
-                              key={s}
-                              className="text-[10px] tracking-[0.08em] leading-none"
-                              style={{ color: 'var(--band-soft)', border: '1px solid var(--band-hair)', padding: '3px 6px' }}
-                            >
-                              {s}
-                            </span>
-                          ))}
-                        </span>
-                      )}
-                    </span>
-                    <span className="text-base font-medium tabular-nums" style={{ fontFamily: 'var(--font-serif)', color: pres.totalColor }}>
-                      {pres.totalText}
-                    </span>
-                    <span
-                      className="flex items-center gap-[7px] text-[11.5px] justify-self-end justify-end min-w-16"
-                      style={{ color: pres.statusColor }}
-                    >
-                      <span
-                        className="w-[7px] h-[7px] rounded-full"
-                        style={{ border: `1px solid ${pres.dotBorder}`, background: pres.dotBg }}
-                      />
-                      {t(pres.statusKey)}
-                    </span>
+                    <span style={{ color: 'var(--band-soft)' }}>{r.label}</span>
+                    <span className="text-[13.5px] tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{r.value}</span>
                   </div>
-                );
-              })}
-            </div>
+                ))}
+                <div className="flex justify-between items-baseline gap-4 py-[7px] text-[12.5px]" style={{ borderTop: '1px solid var(--band-hair-soft)' }}>
+                  <span style={{ color: 'var(--band-muted)' }}>{t('sharedSubtotal')}</span>
+                  <span className="text-[13.5px] font-medium tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{evaluation.sharedTotal}</span>
+                </div>
+              </>
+            )}
           </div>
-        ))}
-
-        {!panel && (
-          <p className="mt-[18px] mb-0 text-[11.5px] leading-[1.8]" style={{ color: 'var(--band-muted)' }}>
-            {t('pathNote')}
-          </p>
         )}
 
-        {suggestions.length > 0 && (panel ? (
+        <div className="mt-4" style={{ borderTop: '1px solid var(--band-hair)' }}>
+          {evaluation.jobs.map((je) => (
+            <div key={je.job.id} className="pt-3 pb-2.5" style={{ borderBottom: '1px solid var(--band-hair-soft)' }}>
+              <div className="flex justify-between items-baseline gap-3">
+                <span className="min-w-0 flex items-baseline gap-2.5">
+                  <span className="text-[15px] flex-none" style={{ fontFamily: 'var(--font-serif)' }}>
+                    {String.fromCharCode(65 + je.index)}
+                  </span>
+                  <span className="text-[12.5px] overflow-hidden text-ellipsis whitespace-nowrap" style={{ color: 'var(--band-ink)' }}>
+                    {je.occupation ? (lang === 'zh' ? je.occupation.zh : je.occupation.en) : t('noOccName')}
+                  </span>
+                </span>
+                <span className="flex-none text-[14px] tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>{je.base}</span>
+              </div>
+              <div className="flex gap-4 mt-1.5 flex-wrap">
+                {je.pathways.map((p) => {
+                  const pres = presentPath(p);
+                  return (
+                    <span key={p.code} className="flex items-center gap-1.5 text-[11.5px] tabular-nums" style={{ color: pres.statusColor }}>
+                      <span className="w-[6px] h-[6px] rounded-full flex-none" style={{ border: `1px solid ${pres.dotBorder}`, background: pres.dotBg }} />
+                      {p.code}&nbsp;{pres.totalText}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {suggestions.length > 0 && (
           <div className="mt-3.5">
             {suggestions.slice(0, 3).map((s) => (
               <div key={s.key} className="flex gap-3 items-baseline pt-2 text-[12px] leading-[1.5]">
@@ -383,23 +264,9 @@ export default function ResultsBand({
               </div>
             ))}
           </div>
-        ) : (
-          <div className="mt-[26px] px-5 pt-[18px] pb-5" style={{ border: '1px solid var(--band-hair)' }}>
-            <div className="text-[11.5px] tracking-[0.22em] font-medium" style={{ color: 'var(--band-muted)' }}>
-              {t('suggestionCaps')}
-            </div>
-            {suggestions.map((s) => (
-              <div key={s.key} className="flex gap-3.5 items-baseline pt-3 text-[13px] leading-[1.55]">
-                <span className="flex-none text-sm tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>
-                  +{s.points}
-                </span>
-                <span style={{ color: 'var(--band-soft)' }}>{t(`sug.${s.key}`)}</span>
-              </div>
-            ))}
-          </div>
-        ))}
+        )}
 
-        <div className={panel ? 'flex flex-wrap items-center gap-2.5 mt-6' : 'flex flex-wrap items-center gap-2.5 mt-[34px]'}>
+        <div className="flex flex-wrap items-center gap-2.5 mt-6">
           <button
             type="button"
             onClick={onOpenExport}


### PR DESCRIPTION
## Summary

Mobile page length complaint: section 03 still used the full-size band on phones (per-job bordered cards + three pathway rows + state chip rows each — ~2600px for three assessments). The compact panel layout (62px headline, collapsible breakdown now incl. subtotal, two-line job rows with inline pathway dots, trimmed suggestions) becomes the single results view on every breakpoint; the dual-instance render and the whole full-variant code path are removed. State chips stay discoverable in section 05.

Measured on 390px with 3 assessments: section 03 = 687px, total page 4145px (~⅓ shorter), order 01→05 intact, no horizontal scroll.

## Test plan
- [x] 106/106 vitest, tsc, build
- [x] Browser 390px: heights/order/overflow as above; wide layout sticky panel unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v