### PR TITLE
fix: two-round audit findings — employment cap, ACECQA, data refresh

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -26,7 +26,7 @@
     "lang": "Language"
   },
   "boxes": {
-    "stem": "STEM / IT Masters by research or PhD (2 yrs)",
+    "stem": "STEM / IT Masters by research or PhD at an Australian institution (2 yrs)",
     "ausStudy": "Australian study (2 yrs full-time)",
     "regionalStudy": "Regional study (2 yrs)",
     "communityLanguage": "NAATI certification (CCL / Interpreter / Translator)"
@@ -54,7 +54,7 @@
     "partnerStatus": {
       "none": "Partner without claimable points",
       "single": "Single applicant",
-      "partnerSkills": "Partner with skills assessment",
+      "partnerSkills": "Partner with skills assessment + competent English",
       "partnerCitizen": "Partner is AU citizen / PR",
       "partnerEnglish": "Partner with competent English"
     },
@@ -159,7 +159,7 @@
     },
     "NT": {
       "how": "Offshore MOL · onshore needs NT connection",
-      "tip": "Very limited places in 2025–26, exceptions only"
+      "tip": "About 1,650 places in 2025–26; onshore applicants need NT ties"
     }
   },
   "suggestionCaps": "HOW TO GAIN MORE POINTS",
@@ -221,13 +221,13 @@
     "age33": "Turns 33 — age bracket drops",
     "age40": "Turns 40 — age bracket drops",
     "age45": "Turns 45 — no longer eligible",
-    "ausWork": "Australian work reaches {{years}} yrs",
-    "overseasWork": "Overseas work reaches {{years}} yrs",
+    "ausWork": "Australian work reaches the {{years}}-year mark",
+    "overseasWork": "Overseas work reaches the {{years}}-year mark",
     "englishExpiry": "English test result expires",
     "assessmentExpiry": "{{authority}} assessment expires",
     "naatiExpiry": "NAATI CCL credential expires",
-    "ausWorkDrop": "Australian work in the 10-yr window falls below {{years}} yrs",
-    "overseasWorkDrop": "Overseas work in the 10-yr window falls below {{years}} yrs"
+    "ausWorkDrop": "Australian work in the 10-yr window falls below the {{years}}-year mark",
+    "overseasWorkDrop": "Overseas work in the 10-yr window falls below the {{years}}-year mark"
   },
   "tlToday": "TODAY",
   "tlGoalLine": "Goal {{n}}",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -26,7 +26,7 @@
     "lang": "语言"
   },
   "boxes": {
-    "stem": "STEM / IT 研究型硕士或博士（2 年）",
+    "stem": "STEM / IT 研究型硕士或博士(澳洲院校,2 年)",
     "ausStudy": "在澳完成 2 年全日制学习",
     "regionalStudy": "在偏远地区学习 2 年",
     "communityLanguage": "NAATI 社区语言认证（CCL / 口译 / 笔译）"
@@ -54,7 +54,7 @@
     "partnerStatus": {
       "none": "伴侣不符合加分条件",
       "single": "单身申请人",
-      "partnerSkills": "伴侣持有技术评估",
+      "partnerSkills": "配偶/伴侣有职业评估且英语达胜任水平",
       "partnerCitizen": "伴侣为澳洲公民 / 永居",
       "partnerEnglish": "伴侣具备普通英语"
     },
@@ -159,7 +159,7 @@
     },
     "NT": {
       "how": "离岸 MOL 清单 · 在岸看北领地关联",
-      "tip": "2025–26 名额极少，以特殊情形为主"
+      "tip": "2025–26 约 1,650 个名额;在岸申请需北领地关联"
     }
   },
   "suggestionCaps": "如何获得更多分数 · SUGGESTIONS",

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -103,7 +103,8 @@ export default function ExportModal({ open, onClose, evaluation, goal }: ExportM
     if (!canvasRef.current) return;
     const a = document.createElement('a');
     const unit = lang === 'zh' ? '分' : 'pts';
-    a.download = `EOI-${evaluation.bestTotal}${unit}-${todayLabel().replace(/\./g, '-')}.png`;
+    // Filename carries the bare score — same figure every other surface shows
+    a.download = `EOI-${evaluation.bareScore}${unit}-${todayLabel().replace(/\./g, '-')}.png`;
     a.href = canvasRef.current.toDataURL('image/png');
     a.click();
   };

--- a/src/components/ResultsBand.tsx
+++ b/src/components/ResultsBand.tsx
@@ -257,7 +257,8 @@ export default function ResultsBand({
 
         {suggestions.length > 0 && (
           <div className="mt-3.5">
-            {suggestions.slice(0, 3).map((s) => (
+            {/* The MLTSSL structural hint unlocks 189 — never crowd it out */}
+            {[...suggestions.filter((s) => s.key === 'mltssl'), ...suggestions.filter((s) => s.key !== 'mltssl')].slice(0, 3).map((s) => (
               <div key={s.key} className="flex gap-3 items-baseline pt-2 text-[12px] leading-[1.5]">
                 <span className="flex-none text-[12.5px] tabular-nums" style={{ fontFamily: 'var(--font-serif)' }}>+{s.points}</span>
                 <span style={{ color: 'var(--band-soft)' }}>{t(`sug.${s.key}`)}</span>

--- a/src/components/SharedCriteriaSection.tsx
+++ b/src/components/SharedCriteriaSection.tsx
@@ -7,7 +7,7 @@ import CheckRow from './CheckRow';
 import SubMonthRow from './SubMonthRow';
 import type { PlanningDates, SharedCriteria } from '@/lib/types';
 import { isYm } from '@/lib/types';
-import { addMonths, monthsBetween, naatiExpiryMonth } from '@/lib/timeline';
+import { ENGLISH_VALIDITY_MONTHS, addMonths, monthsBetween, naatiExpiryMonth } from '@/lib/timeline';
 import {
   bonusGroups,
   sharedBonusCriteria,
@@ -42,7 +42,7 @@ export default function SharedCriteriaSection({
       : monthsBetween(dates.birth, today) < 18 * 12 ? t('tlUnder18') : undefined)
     : undefined;
   const englishNote = isYm(dates.englishTest)
-    ? t('tlEnglishExpires', { date: addMonths(dates.englishTest, 36) })
+    ? t('tlEnglishExpires', { date: addMonths(dates.englishTest, ENGLISH_VALIDITY_MONTHS) })
     : undefined;
   const naatiNote = shared.communityLanguage && isYm(dates.naatiCert)
     ? t('tlNaatiExpires', { date: naatiExpiryMonth(dates.naatiCert) })

--- a/src/data/assessingAuthorities.ts
+++ b/src/data/assessingAuthorities.ts
@@ -100,9 +100,17 @@ const PREFIX_RULES: Record<string, AuthorityInfo> = {
   // Source: https://www.amsa.gov.au/qualifications-training/international-qualifications/immigration-skills-assessment-mariners
   '2312': { authority: 'AMSA', validityYears: 3 },
 
+  // ── Child Care Centre Manager ── ACECQA, 3 years ─────────────────────────
+  // ACECQA has been the designated authority for 134111 since 15 Nov 2019.
+  // Source: https://www.acecqa.gov.au/qualifications/assessment/skilled-migration
+  '134111': { authority: 'ACECQA', validityYears: 3 },
+
   // ── School Teachers ── AITSL, 3 years ───────────────────────────────────
   // Source: https://www.aitsl.edu.au/teach/understand-the-teaching-profession/teacher-assessment-referral
+  // Exception: 241111 Early Childhood Teacher moved from AITSL to ACECQA
+  // effective 7 Dec 2024 (longest-prefix rule below overrides '241').
   '241':  { authority: 'AITSL', validityYears: 3 }, // School Teachers
+  '241111': { authority: 'ACECQA', validityYears: 3 },
 
   // ── Nursing and Midwifery ── ANMAC, 3 years ─────────────────────────────
   // Source: https://anmac.org.au/assessment/skills-assessment

--- a/src/data/invitationRounds.ts
+++ b/src/data/invitationRounds.ts
@@ -5,8 +5,9 @@
 //   high-demand trades that round. It is NOT a general pass mark: since 2024-25, 189 runs a
 //   few large, roughly quarterly rounds ranked by occupation, and professional / STEM / medical
 //   occupations typically needed 85-115 points in the same round.
-// A June 2026 round is reported by some secondary sources but is unconfirmed/disputed
-//   (conflicts with the 2025-26 planning ceiling), so it is omitted pending official data.
+// The 2026-06 round (4 Jun 2026) is confirmed on the official SkillSelect page:
+//   10,000 invitations. Its 65-pt trades floor comes from corroborated community
+//   trackers (RACC, Magpie Consultants) — DHA does not publish per-round floors.
 export interface InvitationRound {
   date: string;
   visa: '189';
@@ -15,6 +16,7 @@ export interface InvitationRound {
 }
 
 export const invitationRounds: InvitationRound[] = [
+  { date: '2026-06', visa: '189', minimumPoints: 65, invitations: 10000 },
   { date: '2025-11', visa: '189', minimumPoints: 65, invitations: 10000 },
   { date: '2025-08', visa: '189', minimumPoints: 65, invitations: 6887 },
   { date: '2024-11', visa: '189', minimumPoints: 65, invitations: 15000 },

--- a/src/data/pointsCriteria.ts
+++ b/src/data/pointsCriteria.ts
@@ -82,6 +82,14 @@ export type JobSelectField = keyof typeof jobSelectCriteria;
 export const professionalYearPoints = 5;
 
 /**
+ * Part 6D.5 item 6D51: when an applicant qualifies under both Part 6D.3
+ * (overseas employment) and Part 6D.4 (Australian employment) and the
+ * combined points exceed 20, exactly 20 points are awarded.
+ * Source: Migration Regulations 1994 Schedule 6D (verified 2026-07-03).
+ */
+export const EMPLOYMENT_EXPERIENCE_CAP = 20;
+
+/**
  * Visa pathways. `lists` is the federal occupation-list gate.
  * `perState` pathways additionally depend on each state's own occupation list
  * (see stateLists.ts) — the nomination bonus is only claimable with a nomination.
@@ -100,7 +108,8 @@ export const pathways: Pathway[] = [
 ];
 
 export const MIN_POINTS = 65;
-export const GOAL_RANGE = { min: 65, max: 120, step: 5 } as const;
+// max = theoretical best base score: shared 105 + capped employment 20 + PY 5
+export const GOAL_RANGE = { min: 65, max: 130, step: 5 } as const;
 export const MAX_JOBS = 5;
 
 export function optionPoints(options: PointOption[], value: string): number {

--- a/src/data/stateLists.ts
+++ b/src/data/stateLists.ts
@@ -28,7 +28,7 @@ export interface StateInfo {
 
 /** Metadata per state; descriptive how/tip strings live in the locale files under `states.<code>` */
 export const states: StateInfo[] = [
-  { code: 'NSW', url: 'https://www.nsw.gov.au/visas-and-migration' },
+  { code: 'NSW', url: 'https://www.nsw.gov.au/visas-and-migration/skilled-visas/nsw-skills-lists' },
   { code: 'VIC', url: 'https://liveinmelbourne.vic.gov.au' },
   { code: 'QLD', url: 'https://migration.qld.gov.au' },
   { code: 'WA', url: 'https://migration.wa.gov.au' },

--- a/src/lib/points.ts
+++ b/src/lib/points.ts
@@ -2,6 +2,7 @@ import type { JobAssessment, SharedCriteria } from './types';
 import type { Occupation } from '@/data/occupations';
 import { occupations } from '@/data/occupations';
 import {
+  EMPLOYMENT_EXPERIENCE_CAP,
   MIN_POINTS,
   jobSelectCriteria,
   optionPoints,
@@ -101,7 +102,9 @@ export function evaluate(shared: SharedCriteria, jobs: JobAssessment[]): Evaluat
 
   const jobEvaluations: JobEvaluation[] = jobs.map((job, index) => {
     const points = calculateJobPoints(job);
-    const base = sharedTotal + points.ausWork + points.overseasWork + points.professionalYear;
+    // Part 6D.5 item 6D51: combined AU + overseas employment points cap at 20
+    const employment = Math.min(points.ausWork + points.overseasWork, EMPLOYMENT_EXPERIENCE_CAP);
+    const base = sharedTotal + employment + points.professionalYear;
     const occupation = findOccupation(job.anzsco);
 
     const pathwayResults: PathwayResult[] = pathways.map((p) => {

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -145,7 +145,8 @@ export function groupCauses(causes: TimelineCause[]): GroupedCause[] {
 // —— constants ———————————————————————————————————————————————————————————————
 
 const HORIZON_MONTHS = 60;
-const ENGLISH_VALIDITY_MONTHS = 36;
+/** Points-test English results must come from a test taken in the prior 3 years */
+export const ENGLISH_VALIDITY_MONTHS = 36;
 
 // Causes that carry no score change — only a user warning.
 const WARNING_KINDS = new Set<TimelineCause['kind']>([

--- a/tests/assessingAuthorities.test.ts
+++ b/tests/assessingAuthorities.test.ts
@@ -18,8 +18,16 @@ describe('assessingAuthority', () => {
 
   it('maps accountants, teachers and nurses to their bodies', () => {
     expect(assessingAuthority('221111').authority).toMatch(/CPA/);
-    expect(assessingAuthority('241111').authority).toBe('AITSL');
+    // Secondary teachers stay with AITSL…
+    expect(assessingAuthority('241411').authority).toBe('AITSL');
     expect(assessingAuthority('254411').authority).toBe('ANMAC');
+  });
+
+  it('maps early-childhood occupations to ACECQA', () => {
+    // 241111 moved from AITSL to ACECQA effective 7 Dec 2024
+    expect(assessingAuthority('241111')).toEqual({ authority: 'ACECQA', validityYears: 3 });
+    // 134111 Child Care Centre Manager has been ACECQA since 2019
+    expect(assessingAuthority('134111')).toEqual({ authority: 'ACECQA', validityYears: 3 });
   });
 
   it('falls back to TRA for trades (major group 3) and VETASSESS otherwise', () => {

--- a/tests/points.test.ts
+++ b/tests/points.test.ts
@@ -288,3 +288,28 @@ describe('data integrity', () => {
     }
   });
 });
+
+describe('combined employment cap (Part 6D.5 item 6D51)', () => {
+  const shared = { age: '25-32', english: 'ielts8', education: 'bachelor', partnerStatus: 'single', stem: false, ausStudy: false, regionalStudy: false, communityLanguage: false };
+  const job = (o = {}) => ({ id: 'j1', anzsco: '261313', ausWork: '', overseasWork: '', professionalYear: false, ausWorkStart: '', ausWorkEnd: '', overseasWorkStart: '', overseasWorkEnd: '', assessmentDate: '', ...o });
+
+  it('caps AU + overseas employment points at 20', () => {
+    // shared = 30+20+15+10 = 75; aus 8-10 (20) + ovs 8-10 (15) would be 35 uncapped
+    const ev = evaluate(shared, [job({ ausWork: '8-10', overseasWork: '8-10' })]);
+    expect(ev.jobs[0].base).toBe(75 + 20);
+  });
+
+  it('leaves combinations at or under 20 untouched', () => {
+    // aus 3-5 (10) + ovs 5-8 (10) = exactly 20
+    const ev = evaluate(shared, [job({ ausWork: '3-5', overseasWork: '5-8' })]);
+    expect(ev.jobs[0].base).toBe(75 + 20);
+    // aus 1-3 (5) + ovs 3-5 (5) = 10
+    const ev2 = evaluate(shared, [job({ ausWork: '1-3', overseasWork: '3-5' })]);
+    expect(ev2.jobs[0].base).toBe(75 + 10);
+  });
+
+  it('applies the cap before adding Professional Year points', () => {
+    const ev = evaluate(shared, [job({ ausWork: '8-10', overseasWork: '8-10', professionalYear: true })]);
+    expect(ev.jobs[0].base).toBe(75 + 20 + 5);
+  });
+});


### PR DESCRIPTION
## Summary

Two-round audit (functionality + information accuracy): three parallel round-1 auditors (functional code / points rules vs Schedule 6D / domain data vs official sources) plus my browser sweep; round-2 adversarial verifiers confirmed every Critical against primary or corroborated sources before fixing.

### Critical (confirmed with provision text / official pages)
- **Combined employment cap**: Sch 6D item 6D51 caps AU+overseas work points at 20; `evaluate()` summed uncapped (up to 35 → 15 phantom points). Verified in-browser: maxed scenario 140 → 125.
- **ACECQA**: 134111 Child Care Centre Manager (ACECQA since 2019, was falling to VETASSESS) and 241111 Early Childhood Teacher (AITSL → ACECQA effective 7 Dec 2024).

### Important
- 2026-06 invitation round confirmed on official SkillSelect (10,000 invitations; 65 floor from corroborated community trackers, noted as such) — was omitted as "disputed".
- Export filename used `bestTotal` while every other surface shows `bareScore`.

### Minor
Goal ceiling 120→130 (real base max under the cap); partner-skills label now states the competent-English co-requirement (6D111); STEM label states the Australian-institution requirement; NT copy corrected (1,650 places 2025-26 — more than ACT, not "exceptions only"); precise NSW skills-list URL; `ENGLISH_VALIDITY_MONTHS` shared instead of a hardcoded 36; MLTSSL 189-unlock hint prioritised in panel suggestions; EN milestone labels use "-year mark" phrasing (no more "1 yrs").

Audit trail: `.superpowers/sdd/audit-r1-{functional,points,domain}.md`, `audit-r2-{points,domain}-verify.md` (local, gitignored).

## Test plan
- [x] 110/110 vitest (new: cap boundary cases incl. exactly-20 and cap-before-PY; ACECQA mappings)
- [x] tsc, next build
- [x] Browser: capped headline 125, goal max 130, updated labels rendering in zh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v