### PR TITLE
fix: respect iOS safe areas in standalone mode

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,9 @@ export const viewport = {
     { media: '(prefers-color-scheme: light)', color: '#F2EFE6' },
     { media: '(prefers-color-scheme: dark)', color: '#1E1C17' },
   ],
+  // Standalone iOS draws the page behind the status bar; cover + explicit
+  // safe-area padding (nav bar, floating elements) keeps that zone ours.
+  viewportFit: 'cover' as const,
 };
 
 export const metadata = {

--- a/src/components/FloatingChip.tsx
+++ b/src/components/FloatingChip.tsx
@@ -17,8 +17,9 @@ export default function FloatingChip({ visible, total, onClick }: FloatingChipPr
       type="button"
       onClick={onClick}
       title={t('chipHint')}
-      className="fixed right-[22px] bottom-[22px] z-40 flex items-baseline gap-2.5 px-[18px] py-[11px] cursor-pointer wide:hidden"
+      className="fixed right-[22px] z-40 flex items-baseline gap-2.5 px-[18px] py-[11px] cursor-pointer wide:hidden"
       style={{
+        bottom: 'calc(22px + env(safe-area-inset-bottom, 0px))',
         background: 'var(--band-bg)',
         color: 'var(--band-ink)',
         border: '1px solid var(--band-border)',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -59,8 +59,10 @@ export default function Header() {
     // position:sticky can pin it for the whole page, not just the header.
     <>
       <div
-        className="sticky top-0 z-40 pt-[22px] pb-3.5"
+        className="sticky top-0 z-40 pb-3.5"
         style={{
+          // 22px of our own air + the iOS standalone status-bar inset
+          paddingTop: 'calc(22px + env(safe-area-inset-top, 0px))',
           background: 'color-mix(in srgb, var(--bg) 86%, transparent)',
           backdropFilter: 'blur(10px)',
           WebkitBackdropFilter: 'blur(10px)',

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -77,8 +77,9 @@ export default function InstallPrompt() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed bottom-[18px] left-[18px] right-[18px] sm:left-auto sm:w-[340px] z-50 px-[18px] py-4"
+      className="fixed left-[18px] right-[18px] sm:left-auto sm:w-[340px] z-50 px-[18px] py-4"
       style={{
+        bottom: 'calc(18px + env(safe-area-inset-bottom, 0px))',
         background: 'var(--band-bg)',
         color: 'var(--band-ink)',
         boxShadow: 'var(--shadow)',


### PR DESCRIPTION
## Summary

User's standalone-PWA screenshot showed page content bleeding behind the iOS status bar (the clock row sat on raw scrolled content, with a gap above the pinned nav bar). Standalone iOS draws the page edge-to-edge, so: `viewport-fit=cover` in the viewport export; the sticky nav bar's top padding becomes `calc(22px + env(safe-area-inset-top))` so its frosted background owns the status-bar zone; FloatingChip and InstallPrompt gain `env(safe-area-inset-bottom)` for the home indicator. `statusBarStyle` stays `default` (dark clock text on our cream blur). No change in regular browsers (env() = 0, verified).

## Test plan
- [x] 110/110, tsc, build; viewport meta emits `viewport-fit=cover`
- [x] Desktop: bar padding 22px, pins at y=0 — unchanged
- [ ] iOS device: relaunch the installed app (or re-add) — clock should sit on the frosted cream bar, no content bleed
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v