### PR TITLE
fix: stop status-bar bleed in iOS standalone via body scrolling

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -174,7 +174,13 @@ const PageContent = () => {
 
   const scrollToResults = useCallback(() => {
     const el = bandRef.current;
-    if (el) window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - 32, behavior: 'smooth' });
+    if (!el) return;
+    // Standalone mode scrolls the body, not the window (see globals.css)
+    const bodyScrolls = document.documentElement.classList.contains('standalone');
+    const currentTop = bodyScrolls ? document.body.scrollTop : window.scrollY;
+    const target = { top: el.getBoundingClientRect().top + currentTop - 32, behavior: 'smooth' as const };
+    if (bodyScrolls) document.body.scrollTo(target);
+    else window.scrollTo(target);
   }, []);
 
   if (!ready || !mounted) return <PageSkeleton />;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,6 +89,9 @@ export default function RootLayout({
                 const root = document.documentElement;
                 root.classList.remove('light', 'dark');
                 root.classList.add(theme === 'system' ? systemTheme : theme);
+                if (window.matchMedia('(display-mode: standalone)').matches || navigator.standalone === true) {
+                  root.classList.add('standalone');
+                }
               } catch (e) {}
             `,
           }}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,13 +19,19 @@ export default function Header() {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  // Hairline under the sticky bar only once the page has scrolled
+  // Hairline under the sticky bar only once the page has scrolled.
+  // In standalone mode the body is the scroller (see globals.css), so
+  // listen on both — scroll events don't bubble from body to window.
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 8);
+    const onScroll = () => setScrolled((window.scrollY || document.body.scrollTop) > 8);
     onScroll();
     window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    document.body.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      document.body.removeEventListener('scroll', onScroll);
+    };
   }, []);
 
   const lang = i18n.language?.startsWith('zh') ? 'zh' : 'en';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -108,6 +108,23 @@ body {
   transition: background 0.4s ease, color 0.4s ease;
 }
 
+/* Standalone (installed PWA) on iOS renders scrolled document content
+ * behind the status bar and reports safe-area-inset-top as 0, so padding
+ * fixes can't work. Instead the document never scrolls: body becomes the
+ * scroller, and the status bar always sits over the static html background.
+ * The .standalone class is set pre-paint by the inline script in layout. */
+html.standalone {
+  height: 100%;
+  overflow: hidden;
+}
+
+html.standalone body {
+  height: 100dvh;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 ::selection {
   background: var(--ink);
   color: var(--bg);


### PR DESCRIPTION
## Summary

The safe-area padding fix (#38) didn't help on device: in standalone mode iOS draws scrolled document content behind the status bar **and** reports `env(safe-area-inset-top)` as 0, so no padding value can cover the zone. The reliable pattern: in standalone mode the document never scrolls — `html.standalone { overflow: hidden }` and body becomes the scroller (`height: 100dvh; overflow-y: auto`). The status bar then always sits over the static html background (theme-aware cream/dark), and content physically cannot bleed behind it. The `.standalone` class is applied pre-paint by the existing inline script.

Scroll-coupled code adapted: Header's hairline listens on window **and** body (scroll doesn't bubble); FloatingChip's scroll-to-results picks the active scroller. IO-based chip visibility needs no change.

Debugging notes: initial verification failures were two test-environment artifacts — the long-running dev server was serving stale chunks after repeated `next build` runs clobbered `.next` (restart fixed), and the background tab was frame-throttled to ~1fps which delays rAF-aligned scroll events (frame-aware waits confirmed correct behavior).

## Test plan
- [x] 110/110, tsc, build
- [x] Simulated standalone (class applied): window.scrollY stays 0, body scrolls, navbar pins at y=0, hairline appears after real frames, chip appears at bottom and scrolls band to exact -32 target
- [x] Normal mode untouched (class absent → rules inert)
- [ ] iOS device: relaunch installed app — no content behind the clock at any scroll position
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v