### PR TITLE
fix: stop iOS input auto-zoom; give header chevron edge clearance

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -106,7 +106,16 @@ export default function JobCard({
           aria-expanded={open}
           aria-label={open ? t('collapseJob') : t('expandJob')}
           className="flex-1 min-w-0 flex items-center gap-3 py-3 cursor-pointer text-left hover:bg-[var(--hover)]"
-          style={{ background: 'none', border: 'none', color: 'inherit', paddingLeft: 'clamp(18px, 3.4vw, 28px)', transition: 'background 0.15s ease' }}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: 'inherit',
+            paddingLeft: 'clamp(18px, 3.4vw, 28px)',
+            // Without the remove button the chevron ends the row — keep it
+            // clear of the card edge; with it, the × supplies the margin.
+            paddingRight: canRemove ? '10px' : 'clamp(18px, 3.4vw, 28px)',
+            transition: 'background 0.15s ease',
+          }}
         >
           <span className="text-[16px] leading-none flex-none" style={{ fontFamily: 'var(--font-serif)' }}>{tag}</span>
           {occ ? (
@@ -210,7 +219,7 @@ export default function JobCard({
             onChange={(e) => onUIPatch({ q: e.target.value, open: true })}
             onFocus={() => onUIPatch({ open: true })}
             placeholder={t('jobSearch')}
-            className="w-full box-border px-3.5 py-[13px] text-[13.5px] outline-none focus:border-[var(--muted)]"
+            className="w-full box-border px-3.5 py-[13px] text-[16px] outline-none focus:border-[var(--muted)]"
             style={{
               background: 'var(--bg)',
               border: '1px solid var(--hair)',

--- a/src/components/MonthPicker.tsx
+++ b/src/components/MonthPicker.tsx
@@ -162,11 +162,12 @@ export default function MonthPicker({ id, value, onChange, placeholder, disabled
             {editingYear ? (
               <input
                 autoFocus
+                inputMode="numeric"
                 value={yearDraft}
                 onChange={(e) => setYearDraft(e.target.value.replace(/\D/g, '').slice(0, 4))}
                 onBlur={commitYearDraft}
                 onKeyDown={(e) => { if (e.key === 'Enter') commitYearDraft(); }}
-                className="w-16 text-center text-[15px] tabular-nums outline-none"
+                className="w-16 text-center text-[16px] tabular-nums outline-none"
                 style={{ fontFamily: 'var(--font-serif)', background: 'var(--bg)', border: '1px solid var(--hair)', color: 'var(--ink)', padding: '1px 0' }}
               />
             ) : (


### PR DESCRIPTION
## Summary

Two mobile reports:
1. Picking a month zoomed the page in (and it stayed zoomed): iOS auto-zooms any focused input with font-size < 16px. Both text inputs — the occupation search (13.5px) and the year editor (15px) — move to 16px so the zoom never triggers; the year editor also gets `inputMode="numeric"` (number pad instead of QWERTY).
2. The 基础分 header chevron sat flush against the card border on single-assessment cards: the header button had left padding only. Right padding is now conditional — full clamp when the chevron ends the row, 10px when the × button follows.

## Test plan
- [x] 110/110, tsc
- [x] Browser: both inputs computed 16px, year input inputMode numeric, chevron 19px from card edge on a single card
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v