### PR TITLE
fix: month-picker popovers no longer clipped by the accordion body

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import SelectField, { pointsTag } from './SelectField';
 import CheckRow from './CheckRow';
@@ -87,13 +87,29 @@ export default function JobCard({
 
   const open = !collapsed;
 
+  // Clip the body only while collapsed or mid-height-animation. In the open
+  // steady state overflow stays visible so self-managed popovers (month
+  // pickers) can extend past the card edge; transitionend plus a fallback
+  // timer marks the animation done.
+  const [animating, setAnimating] = useState(false);
+  const prevCollapsed = useRef(collapsed);
+  useEffect(() => {
+    if (prevCollapsed.current === collapsed) return;
+    prevCollapsed.current = collapsed;
+    setAnimating(true);
+    const timer = setTimeout(() => setAnimating(false), 450);
+    return () => clearTimeout(timer);
+  }, [collapsed]);
+
   return (
     <div
       className="mt-3 relative"
       style={{
         border: '1px solid var(--hair)',
         background: 'var(--surface)',
-        zIndex: cardActive ? 30 : 1,
+        // Open card floats above collapsed siblings so its popovers never
+        // paint underneath them; active dropdowns still take precedence.
+        zIndex: cardActive ? 30 : open ? 20 : 1,
         animation: 'eoiFadeUp 0.4s ease backwards',
       }}
     >
@@ -169,8 +185,9 @@ export default function JobCard({
         inert={collapsed}
         className="grid"
         style={{ gridTemplateRows: open ? '1fr' : '0fr', transition: 'grid-template-rows 0.35s cubic-bezier(0.22, 1, 0.36, 1)' }}
+        onTransitionEnd={(e) => { if (e.propertyName === 'grid-template-rows') setAnimating(false); }}
       >
-        <div className={cardActive ? 'overflow-visible' : 'overflow-hidden'}>
+        <div className={cardActive || (open && !animating) ? 'overflow-visible' : 'overflow-hidden'}>
           <div style={{ padding: '0 clamp(18px, 3.4vw, 28px) clamp(18px, 3.4vw, 28px)' }}>
 
       {/* Occupation: searchable dropdown */}


### PR DESCRIPTION
## Summary

User screenshot: the assessment-month picker opened near the card bottom was cut off mid-calendar. The accordion body's clipping wrapper flipped to `overflow-visible` only for SelectField dropdowns and the occupation search (`cardActive`); MonthPicker popovers are self-managed state the card can't see, so they got clipped by `overflow-hidden`.

Now the body clips only when it must: collapsed steady state (0fr row) and during the 0.35s height transition (`animating` flag set on collapsed-change, cleared by `transitionend` on grid-template-rows with a 450ms fallback timer). Open steady state is always `overflow-visible`. The open card additionally floats at z-index 20 above collapsed siblings so an overflowing popover can't paint underneath the next card.

## Test plan
- [x] 110/110, tsc
- [x] Browser: popover extends past the card edge (bottom 2135 vs card 2048) with zero clipping ancestors up to body; overflow is `hidden` mid-animation and `visible` in open steady state; collapsed height 1px
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v