### PR TITLE
fix: stop horizontal page pan in standalone mode

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -187,7 +187,9 @@ export default function JobCard({
         style={{ gridTemplateRows: open ? '1fr' : '0fr', transition: 'grid-template-rows 0.35s cubic-bezier(0.22, 1, 0.36, 1)' }}
         onTransitionEnd={(e) => { if (e.propertyName === 'grid-template-rows') setAnimating(false); }}
       >
-        <div className={cardActive || (open && !animating) ? 'overflow-visible' : 'overflow-hidden'}>
+        {/* min-w-0: with overflow visible the grid item's automatic minimum
+            width is min-content, which lets nowrap text widen the card */}
+        <div className={`min-w-0 ${cardActive || (open && !animating) ? 'overflow-visible' : 'overflow-hidden'}`}>
           <div style={{ padding: '0 clamp(18px, 3.4vw, 28px) clamp(18px, 3.4vw, 28px)' }}>
 
       {/* Occupation: searchable dropdown */}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -121,7 +121,10 @@ html.standalone {
 html.standalone body {
   height: 100dvh;
   min-height: 0;
-  overflow-y: auto;
+  /* x hidden, y auto — overflow-y alone would compute overflow-x to auto
+     and allow sideways panning. Shorthand form: Lightning CSS drops a
+     longhand overflow-x next to overflow-y when minifying. */
+  overflow: hidden auto;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Summary

User's standalone screenshot showed the page panned sideways — left edge of all copy clipped, card content extending past the right edge. Root cause chain from the #41 popover-clip fix:

1. The accordion body wrapper is a **grid item**; with `overflow-hidden` its automatic minimum width was 0, but flipping to `overflow-visible` in the open steady state restored `min-width: min-content` — nowrap text (the selected-occupation display row) widened the whole card body to 502px on a 384px viewport. Fix: `min-w-0` on the wrapper; the row's existing truncation chain works again (verified: scrollWidth 502 → 384, name span ellipsizes).
2. In standalone mode the body is the scroller with `overflow-y: auto`, which computes `overflow-x` to `auto` — any such overflow became a horizontal pan. Fix: `overflow: hidden auto`. The two-value shorthand is deliberate: Lightning CSS (Tailwind v4 minifier) silently **drops** a longhand `overflow-x: hidden` declared alongside `overflow-y: auto`; the shorthand survives compilation (verified in the emitted chunk).

## Test plan
- [x] 110/110, tsc
- [x] 390px simulated standalone: body overflowX `hidden`, scrollWidth = clientWidth = 384, forced `scrollLeft = 100` snaps back to 0, vertical scroll unaffected
- [x] Regression: month-picker popover still unclipped (zero clipping ancestors); accordion expand/collapse still animates with mid-transition clipping
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjCx9QV39Pt8hDc2wveL5v