### PR TITLE
Fix fixed-element overlaps and add scroll affordance on mobile

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -51,7 +51,10 @@ const PageContent = () => {
   const [copied, setCopied] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
   const [chipShown, setChipShown] = useState(false);
+  const [footerNear, setFooterNear] = useState(false);
+  const [installPromptVisible, setInstallPromptVisible] = useState(false);
   const bandRef = useRef<HTMLDivElement | null>(null);
+  const footerRef = useRef<HTMLDivElement | null>(null);
 
   // today as YYYY-MM — PageContent only renders after the mounted gate, so this is client-safe
   const today = useMemo(() => {
@@ -100,6 +103,19 @@ const PageContent = () => {
     return () => io.disconnect();
   }, [ready, mounted]);
 
+  // ...and hides again once the footer scrolls into view, so the fixed chip
+  // never sits on top of the footer's links at the bottom of the page.
+  useEffect(() => {
+    const el = footerRef.current;
+    if (!el || !('IntersectionObserver' in window)) return;
+    const io = new IntersectionObserver(
+      (entries) => setFooterNear(entries[0].isIntersecting),
+      { threshold: 0 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [ready, mounted]);
+
   const patchDates = useCallback((patch: Partial<PlanningDates>) => {
     setDates((prev) => ({ ...prev, ...patch }));
   }, []);
@@ -137,7 +153,7 @@ const PageContent = () => {
 
   if (!ready || !mounted) return <PageSkeleton />;
 
-  const chipVisible = chipShown && bareScore > 0 && !exportOpen;
+  const chipVisible = chipShown && bareScore > 0 && !exportOpen && !footerNear && !installPromptVisible;
   const hasProfile = jobs.some((j) => j.anzsco !== '');
 
   return (
@@ -192,10 +208,12 @@ const PageContent = () => {
       <FeeEstimateSection evaluation={evaluation} shared={shared} />
       <Pr191Section dates={dates} onDatesPatch={patchDates} today={today} />
 
-      <Footer />
+      <div ref={footerRef}>
+        <Footer />
+      </div>
 
       <FloatingChip visible={chipVisible} total={bareScore} onClick={scrollToResults} />
-      <InstallPrompt />
+      <InstallPrompt onVisibilityChange={setInstallPromptVisible} />
 
       <ExportModal
         open={exportOpen}

--- a/src/components/ComparisonTable.tsx
+++ b/src/components/ComparisonTable.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Evaluation } from '@/lib/points';
 import { bestPathwayForJob, hasOccupation } from '@/lib/points';
+import HScrollFade from './HScrollFade';
 
 interface ComparisonTableProps {
   evaluation: Evaluation;
@@ -27,10 +28,11 @@ function ComparisonTable({ evaluation }: ComparisonTableProps) {
   if (rows.length < 2) return null;
 
   return (
-    <div className="mt-[22px] mb-[6px]" style={{ overflowX: 'auto' }}>
+    <div className="mt-[22px] mb-[6px]">
       <div className="text-[0.71875rem] tracking-[0.16em] font-medium mb-2.5" style={{ color: 'var(--muted)' }}>
         {t('compareTitle')}
       </div>
+      <HScrollFade>
       <table className="w-full text-[0.8125rem]" style={{ borderCollapse: 'collapse', minWidth: '520px' }}>
         <thead>
           <tr style={{ borderBottom: '1px solid var(--ink)' }}>
@@ -65,6 +67,7 @@ function ComparisonTable({ evaluation }: ComparisonTableProps) {
           })}
         </tbody>
       </table>
+      </HScrollFade>
     </div>
   );
 }

--- a/src/components/HScrollFade.tsx
+++ b/src/components/HScrollFade.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface HScrollFadeProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Horizontal-scroll wrapper for content that can be wider than its
+ * container (the timeline chart, the comparison table) on narrow
+ * viewports. Shows a right-edge fade while there's more to scroll to,
+ * since a bare `overflow-x-auto` gives no hint the content continues.
+ */
+export default function HScrollFade({ children }: HScrollFadeProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const update = () => {
+      const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft;
+      setHasOverflow(remaining > 4);
+    };
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', update);
+      ro.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className="relative">
+      <div ref={scrollRef} className="overflow-x-auto">
+        {children}
+      </div>
+      {hasOverflow && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute top-0 right-0 bottom-0 w-10"
+          style={{ background: 'linear-gradient(to right, transparent, var(--bg) 85%)' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -10,6 +10,12 @@ interface BeforeInstallPromptEvent extends Event {
   userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
 }
 
+interface InstallPromptProps {
+  /** Fires whenever the banner mounts/unmounts, so a page can keep other
+   *  fixed bottom-anchored elements (e.g. FloatingChip) from sitting under it. */
+  onVisibilityChange?: (visible: boolean) => void;
+}
+
 /** iOS share glyph — the hint references the button this draws */
 function ShareGlyph() {
   return (
@@ -25,10 +31,15 @@ function ShareGlyph() {
  * standalone) visitors get a one-time "share → add to Home Screen" hint;
  * Chromium browsers get a custom install button via beforeinstallprompt.
  */
-export default function InstallPrompt() {
+export default function InstallPrompt({ onVisibilityChange }: InstallPromptProps) {
   const { t } = useTranslation();
   const [mode, setMode] = useState<'ios' | 'chromium' | null>(null);
   const bipRef = useRef<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    onVisibilityChange?.(mode !== null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
 
   useEffect(() => {
     try {

--- a/src/components/TimelineChart.tsx
+++ b/src/components/TimelineChart.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { addMonths, monthsBetween } from '@/lib/timeline';
 import type { TimelineResult } from '@/lib/timeline';
 import { MIN_POINTS } from '@/data/pointsCriteria';
+import HScrollFade from './HScrollFade';
 
 interface TimelineChartProps {
   timeline: TimelineResult;
@@ -147,7 +148,7 @@ function TimelineChart({ timeline, goal, today, focusEventIndex = null, seriesLa
           </span>
         ))}
       </div>
-      <div className="overflow-x-auto">
+      <HScrollFade>
       <svg
         viewBox={`0 0 ${W} ${H}`}
         role="img"
@@ -291,7 +292,7 @@ function TimelineChart({ timeline, goal, today, focusEventIndex = null, seriesLa
           </g>
         )}
       </svg>
-      </div>
+      </HScrollFade>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Audit round 3 of the layout restructure — a dedicated multi-viewport/theme/locale visual sweep (Playwright across 375/390/768/1024/1400/1600px, light/dark, en/zh, on all 3 pages). The width-consistency fix from rounds 1-2 held up (pixel-identical container geometry across `/`, `/profile`, `/sponsorship` at every width tested, no page ever triggers document-level horizontal scroll). Two real overlap bugs and one discoverability gap turned up on mobile specifically:

- **FloatingChip vs Footer**: the fixed "jump to score" chip covered the footer's GitHub/LinkedIn/Website links at the true bottom of the Independent Migration page on phone widths — confirmed via `elementFromPoint` that the links were actually unclickable, not just visually covered, and there's no way to scroll further to reveal them. Fixed by adding a second `IntersectionObserver` (on a footer wrapper) that hides the chip once the footer scrolls into view.
- **FloatingChip vs InstallPrompt**: the chip also rendered fully behind the PWA install banner (higher z-index, near-identical bottom-right anchor) whenever both were visible, hiding the score shortcut behind the install nudge for first-time mobile visitors. `InstallPrompt` now reports its own visibility via an `onVisibilityChange` callback so `HomeClient` can fold it into the chip's visibility.
- **Scroll discoverability**: `TimelineChart` and `ComparisonTable` both scroll horizontally past their container on narrow viewports with no visual hint there's more content — for the timeline chart this can hide the actual projected end-state score, which is core information. Added a shared `HScrollFade` wrapper (right-edge gradient while unscrolled content remains) around both.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 151/151 passing
- [x] `npm run build` — clean production build
- [x] Playwright: at the true bottom of `/` on a 390px viewport, the chip is hidden and `elementFromPoint` on the footer's GitHub link resolves to the `<a>` tag (previously resolved to the chip `<button>`)
- [x] Playwright: chip still shows correctly once scrolled past the results band but before the footer
- [x] Playwright: with an iOS Safari UA (triggers `InstallPrompt`), the chip stays hidden while the install banner is visible — no overlap
- [x] Playwright: `HScrollFade`'s edge gradient renders on both the timeline chart and the comparison table at 375px, where their content (560px / 520px) exceeds the container width

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WKuZiftbPDHUWfSC89vWNm


---
_Generated by [Claude Code](https://claude.ai/code/session_01WKuZiftbPDHUWfSC89vWNm)_